### PR TITLE
fix: use httpconfiguration base URLs for events and config manager

### DIFF
--- a/client.go
+++ b/client.go
@@ -63,9 +63,11 @@ type service struct {
 }
 
 func InitializeLocalBucketing(environmentKey string, options *DVCOptions) (ret *DevCycleLocalBucketing, err error) {
+	cfg := NewConfiguration(options)
+
 	options.CheckDefaults()
 	ret = &DevCycleLocalBucketing{}
-	err = ret.Initialize(environmentKey, options)
+	err = ret.Initialize(environmentKey, options, cfg)
 	if err != nil {
 		log.Println(err)
 		return nil, err
@@ -77,9 +79,6 @@ func InitializeLocalBucketing(environmentKey string, options *DVCOptions) (ret *
 // optionally pass a custom http.Client to allow for advanced features such as caching.
 func NewDVCClient(environmentKey string, options *DVCOptions, localBucketing *DevCycleLocalBucketing) (*DVCClient, error) {
 	cfg := NewConfiguration(options)
-	if cfg.HTTPClient == nil {
-		cfg.HTTPClient = http.DefaultClient
-	}
 
 	options.CheckDefaults()
 

--- a/configuration.go
+++ b/configuration.go
@@ -109,6 +109,7 @@ func NewConfiguration(options *DVCOptions) *HTTPConfiguration {
 		EventsAPIBasePath: eventsApiBasePath,
 		DefaultHeader:     make(map[string]string),
 		UserAgent:         "DevCycle-Server-SDK/" + VERSION + "/go",
+		HTTPClient:        http.DefaultClient,
 	}
 	return cfg
 }

--- a/eventqueue.go
+++ b/eventqueue.go
@@ -38,7 +38,7 @@ type EventQueueOptions struct {
 
 func (e *EventQueue) initialize(options *DVCOptions, localBucketing *DevCycleLocalBucketing) error {
 	e.context = context.Background()
-	e.httpClient = http.DefaultClient
+	e.httpClient = localBucketing.cfg.HTTPClient
 	e.options = options
 	if !e.options.EnableCloudBucketing && localBucketing != nil {
 		e.localBucketing = localBucketing
@@ -127,7 +127,7 @@ func (e *EventQueue) checkEventQueueSize() (bool, error) {
 }
 
 func (e *EventQueue) FlushEvents() (err error) {
-	eventsHost := e.options.EventsAPIOverride
+	eventsHost := e.localBucketing.cfg.EventsAPIBasePath
 	e.localBucketing.startFlushEvents()
 	defer e.localBucketing.finishFlushEvents()
 	events, err := e.localBucketing.flushEventQueue()

--- a/localbucketing.go
+++ b/localbucketing.go
@@ -3,13 +3,14 @@ package devcycle
 import (
 	_ "embed"
 	"encoding/json"
-	"github.com/bytecodealliance/wasmtime-go/v3"
 	"log"
 	"math/rand"
 	"sync"
 	"time"
 	"unicode/utf16"
 	"unsafe"
+
+	"github.com/bytecodealliance/wasmtime-go/v3"
 )
 
 type DevCycleLocalBucketing struct {
@@ -24,6 +25,7 @@ type DevCycleLocalBucketing struct {
 	eventQueue    *EventQueue
 	sdkKey        string
 	options       *DVCOptions
+	cfg           *HTTPConfiguration
 	wasmMutex     sync.Mutex
 	flushMutex    sync.Mutex
 }
@@ -35,10 +37,11 @@ func (d *DevCycleLocalBucketing) SetSDKToken(token string) {
 	d.sdkKey = token
 }
 
-func (d *DevCycleLocalBucketing) Initialize(sdkToken string, options *DVCOptions) (err error) {
+func (d *DevCycleLocalBucketing) Initialize(sdkToken string, options *DVCOptions, cfg *HTTPConfiguration) (err error) {
 	options.CheckDefaults()
 	d.sdkKey = sdkToken
 	d.options = options
+	d.cfg = cfg
 	d.wasm = wasmBinary
 	d.eventQueue = &EventQueue{}
 	d.wasiConfig = wasmtime.NewWasiConfig()
@@ -111,7 +114,7 @@ func (d *DevCycleLocalBucketing) Initialize(sdkToken string, options *DVCOptions
 		return err
 	}
 
-	err = d.configManager.Initialize(sdkToken, d.options)
+	err = d.configManager.Initialize(sdkToken, d)
 	return err
 }
 


### PR DESCRIPTION
Fix the default value for the events queue by passing around the HttpConfiguration object derived from the client options, which contains the correct values for the base CDN and events API URLs.