### PR TITLE
add oninitialized channel that allows the user to make calls before the client is initialized

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -62,6 +62,7 @@ type DVCOptions struct {
 	FlushEventQueueSize          int           `json:"minEventsPerFlush,omitempty"`
 	ConfigCDNURI                 string
 	EventsAPIURI                 string
+	OnInitializedChannel         chan bool
 	BucketingAPIURI              string
 }
 

--- a/example/local/main.go
+++ b/example/local/main.go
@@ -15,7 +15,7 @@ func main() {
 	auth := context.WithValue(context.Background(), devcycle.ContextAPIKey, devcycle.APIKey{
 		Key: environmentKey,
 	})
-
+	onInitialized := make(chan bool)
 	dvcOptions := devcycle.DVCOptions{
 		EnableEdgeDB:                 false,
 		EnableCloudBucketing:         false,
@@ -24,6 +24,7 @@ func main() {
 		RequestTimeout:               10 * time.Second,
 		DisableAutomaticEventLogging: false,
 		DisableCustomEventLogging:    false,
+		OnInitializedChannel:         onInitialized,
 	}
 
 	client, _ := devcycle.NewDVCClient(environmentKey, &dvcOptions)
@@ -32,6 +33,9 @@ func main() {
 	for key, feature := range features {
 		log.Printf("Key:%s, feature:%s", key, feature)
 	}
+
+	<-onInitialized
+	log.Printf("client initialized")
 
 	variables, _ := client.DevCycleApi.AllVariables(auth, user)
 	for key, variable := range variables {


### PR DESCRIPTION
How it works:
- The user can choose to pass in an "OnInitializedChannel" into DVCOptions
- If this channel exists then the initialization process will be run in a go routine, meaning client calls can be made before the bucketing lib is initialized
- The user can listen on the channel to block the main process until init is complete
- By not passing in the channel param the sdk will behave the same as it did before