### PR TITLE
use a single global allocation of platform data for cloud requests

### DIFF
--- a/eventqueue.go
+++ b/eventqueue.go
@@ -69,7 +69,7 @@ func (e *EventQueue) initialize(options *DVCOptions, localBucketing *DevCycleLoc
 	return nil
 }
 
-func (e *EventQueue) QueueEvent(user dvcPopulatedUser, event DVCEvent) error {
+func (e *EventQueue) QueueEvent(user DVCUser, event DVCEvent) error {
 	if e.closed {
 		log.Println("DevCycle client was closed, no more events can be tracked.")
 		return fmt.Errorf("DevCycle client was closed, no more events can be tracked.")

--- a/localbucketing.go
+++ b/localbucketing.go
@@ -96,7 +96,7 @@ func (d *DevCycleLocalBucketing) Initialize(sdkToken string, options *DVCOptions
 	d.configManager = &EnvironmentConfigManager{localBucketing: d}
 
 	platformData := PlatformData{}
-	platformData = *platformData.Default(true)
+	platformData = *platformData.Default()
 	platformJSON, err := json.Marshal(platformData)
 	if err != nil {
 		return err

--- a/model_bucketed_user_config.go
+++ b/model_bucketed_user_config.go
@@ -9,5 +9,5 @@ type BucketedUserConfig struct {
 	Variables            map[string]ReadOnlyVariable `json:"variables"`
 	KnownVariableKeys    []float64                   `json:"knownVariableKeys"`
 
-	user *dvcPopulatedUser
+	user *DVCUser
 }

--- a/model_platformdata.go
+++ b/model_platformdata.go
@@ -14,7 +14,7 @@ type PlatformData struct {
 	Hostname        string `json:"hostname"`
 }
 
-func (pd *PlatformData) Default(isLocal bool) *PlatformData {
+func (pd *PlatformData) Default() *PlatformData {
 	pd.Platform = "Go"
 	pd.SdkType = "server"
 	pd.SdkVersion = VERSION

--- a/model_user_data.go
+++ b/model_user_data.go
@@ -9,9 +9,10 @@
 package devcycle
 
 import (
-	"runtime"
 	"time"
 )
+
+var platformData = (&PlatformData{}).Default()
 
 type DVCUser struct {
 	// Unique id to identify the user
@@ -40,16 +41,9 @@ type DVCUser struct {
 
 type dvcPopulatedUser struct {
 	DVCUser
+	*PlatformData
 	// Date the user was created, Unix epoch timestamp format
 	CreatedDate time.Time `json:"createdDate,omitempty"`
-	// Platform the Client SDK is running on
-	Platform string `json:"platform,omitempty"`
-	// Version of the platform the Client SDK is running on
-	PlatformVersion string `json:"platformVersion,omitempty"`
-	// DevCycle SDK type
-	SdkType string `json:"sdkType,omitempty"`
-	// DevCycle SDK Version
-	SdkVersion string `json:"sdkVersion,omitempty"`
 }
 
 type UserFeatureData struct {
@@ -60,10 +54,7 @@ type UserFeatureData struct {
 func (user *DVCUser) getPopulatedUser() dvcPopulatedUser {
 	return dvcPopulatedUser{
 		*user,
+		platformData,
 		time.Now(),
-		"Go",
-		runtime.Version(),
-		"server",
-		VERSION,
 	}
 }


### PR DESCRIPTION
- re-use a global "platformData" object for cloud requests
- eliminate concept of "populatedUser" for local bucketing because DVCPopulatedUser is already implemented in WASM, and platform data being passed in was a duplicate.