### PR TITLE
fix issues with close logic 

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,6 +67,7 @@ func setLBClient(environmentKey string, options *DVCOptions, c *DVCClient) error
 	localBucketing, err := initializeLocalBucketing(environmentKey, options)
 
 	if err != nil {
+		c.isInitialized = true
 		if options.OnInitializedChannel != nil {
 			go func() {
 				options.OnInitializedChannel <- true
@@ -81,7 +82,7 @@ func setLBClient(environmentKey string, options *DVCOptions, c *DVCClient) error
 	c.localBucketing = localBucketing
 	c.configManager = c.localBucketing.configManager
 	c.eventQueue = c.localBucketing.eventQueue
-	c.isInitialized = c.configManager.HasConfig()
+	c.isInitialized = true
 	if options.OnInitializedChannel != nil {
 		go func() {
 			options.OnInitializedChannel <- true
@@ -158,7 +159,7 @@ DVCClientService Get all features by key for user data
 */
 func (c *DVCClient) AllFeatures(user DVCUser) (map[string]Feature, error) {
 	if !c.DevCycleOptions.EnableCloudBucketing {
-		if c.isInitialized {
+		if c.localBucketing.configManager.hasConfig {
 			user, err := c.generateBucketedConfig(user)
 			return user.Features, err
 		} else {
@@ -223,7 +224,7 @@ func (c *DVCClient) Variable(userdata DVCUser, key string, defaultValue interfac
 	variable := Variable{baseVariable: baseVar, DefaultValue: convertedDefaultValue, IsDefaulted: true}
 
 	if !c.DevCycleOptions.EnableCloudBucketing {
-		if !c.isInitialized {
+		if !c.localBucketing.configManager.hasConfig {
 			log.Println("Variable called before client initialized, returning default value")
 			return variable, nil
 		}
@@ -318,7 +319,7 @@ func (c *DVCClient) AllVariables(user DVCUser) (map[string]ReadOnlyVariable, err
 		localVarReturnValue map[string]ReadOnlyVariable
 	)
 	if !c.DevCycleOptions.EnableCloudBucketing {
-		if c.isInitialized {
+		if c.localBucketing.configManager.hasConfig {
 			user, err := c.generateBucketedConfig(user)
 			if err != nil {
 				return localVarReturnValue, err
@@ -438,12 +439,19 @@ func (c *DVCClient) Close() (err error) {
 		return
 	}
 
-	if c.internalOnInitializedChannel != nil {
+	if !c.isInitialized {
 		log.Println("Awaiting client initialization before closing")
 		<-c.internalOnInitializedChannel
 	}
-	err = c.eventQueue.Close()
-	c.configManager.Close()
+
+	if c.eventQueue != nil {
+		err = c.eventQueue.Close()
+	}
+
+	if c.configManager != nil {
+		c.configManager.Close()
+	}
+
 	return err
 }
 

--- a/client.go
+++ b/client.go
@@ -73,11 +73,11 @@ func setLBClient(environmentKey string, options *DVCOptions, c *DVCClient) error
 			}()
 
 		}
-		go func() {
-			c.internalOnInitializedChannel <- true
-		}()
+		c.internalOnInitializedChannel <- true
+
 		return err
 	}
+
 	c.localBucketing = localBucketing
 	c.configManager = c.localBucketing.configManager
 	c.eventQueue = c.localBucketing.eventQueue
@@ -87,9 +87,7 @@ func setLBClient(environmentKey string, options *DVCOptions, c *DVCClient) error
 			options.OnInitializedChannel <- true
 		}()
 	}
-	go func() {
-		c.internalOnInitializedChannel <- true
-	}()
+	c.internalOnInitializedChannel <- true
 
 	return err
 }
@@ -113,7 +111,7 @@ func NewDVCClient(environmentKey string, options *DVCOptions) (*DVCClient, error
 	c.DevCycleOptions = options
 
 	if !c.DevCycleOptions.EnableCloudBucketing {
-		c.internalOnInitializedChannel = make(chan bool)
+		c.internalOnInitializedChannel = make(chan bool, 1)
 		if c.DevCycleOptions.OnInitializedChannel != nil {
 			go func() {
 				err := setLBClient(environmentKey, options, c)

--- a/client.go
+++ b/client.go
@@ -159,7 +159,7 @@ DVCClientService Get all features by key for user data
 */
 func (c *DVCClient) AllFeatures(user DVCUser) (map[string]Feature, error) {
 	if !c.DevCycleOptions.EnableCloudBucketing {
-		if c.localBucketing.configManager.hasConfig {
+		if c.hasConfig() {
 			user, err := c.generateBucketedConfig(user)
 			return user.Features, err
 		} else {
@@ -224,7 +224,7 @@ func (c *DVCClient) Variable(userdata DVCUser, key string, defaultValue interfac
 	variable := Variable{baseVariable: baseVar, DefaultValue: convertedDefaultValue, IsDefaulted: true}
 
 	if !c.DevCycleOptions.EnableCloudBucketing {
-		if !c.localBucketing.configManager.hasConfig {
+		if !c.hasConfig() {
 			log.Println("Variable called before client initialized, returning default value")
 			return variable, nil
 		}
@@ -319,7 +319,7 @@ func (c *DVCClient) AllVariables(user DVCUser) (map[string]ReadOnlyVariable, err
 		localVarReturnValue map[string]ReadOnlyVariable
 	)
 	if !c.DevCycleOptions.EnableCloudBucketing {
-		if c.localBucketing.configManager.hasConfig {
+		if c.hasConfig() {
 			user, err := c.generateBucketedConfig(user)
 			if err != nil {
 				return localVarReturnValue, err
@@ -453,6 +453,14 @@ func (c *DVCClient) Close() (err error) {
 	}
 
 	return err
+}
+
+func (c *DVCClient) hasConfig() bool {
+	if c.configManager == nil {
+		return false
+	}
+
+	return c.configManager.hasConfig
 }
 
 func (c *DVCClient) performRequest(


### PR DESCRIPTION
- use a buffered channel for the internal initialization system to prevent blocking on writes
- only wait on initialization channel if initialized is false
- change definition of isInitialized to always be true when initialization has finished, even if it was unsuccessful
- change methods like Variable to directly check for whether a config exists rather than checking isInitialized
- increase buffer size of config stop polling channel to prevent problems with calling close when a 403 was received.
