### PR TITLE
move to global logger

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -14,30 +14,26 @@ func TestDVCClient_AllFeatures_Local(t *testing.T) {
 	defer httpmock.DeactivateAndReset()
 	httpConfigMock(200)
 	c, err := NewDVCClient("dvc_server_token_hash", &DVCOptions{})
+	fatalErr(t, err)
 
 	features, err := c.AllFeatures(
 		DVCUser{UserId: "j_test", DeviceModel: "testing"})
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	fatalErr(t, err)
 
 	fmt.Println(features)
-
 }
+
 func TestDVCClient_AllVariablesLocal(t *testing.T) {
 
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	httpConfigMock(200)
 	c, err := NewDVCClient("dvc_server_token_hash", &DVCOptions{})
+	fatalErr(t, err)
 
 	variables, err := c.AllVariables(
 		DVCUser{UserId: "j_test", DeviceModel: "testing"})
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	fatalErr(t, err)
 
 	fmt.Println(variables)
 }
@@ -51,10 +47,7 @@ func TestDVCClient_VariableCloud(t *testing.T) {
 	variable, err := c.Variable(
 		DVCUser{UserId: "j_test", DeviceModel: "testing"},
 		"test", true)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	fatalErr(t, err)
 
 	fmt.Println(variable)
 }
@@ -69,10 +62,7 @@ func TestDVCClient_VariableLocal(t *testing.T) {
 	variable, err := c.Variable(
 		DVCUser{UserId: "j_test", DeviceModel: "testing"},
 		"test", true)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	fatalErr(t, err)
 
 	fmt.Println(variable)
 }
@@ -103,9 +93,8 @@ func TestDVCClient_TrackLocal_QueueEvent(t *testing.T) {
 		FeatureVars: nil,
 		MetaData:    nil,
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	fatalErr(t, err)
+
 	fmt.Println(track)
 }
 
@@ -130,10 +119,15 @@ func TestProduction_Local(t *testing.T) {
 	}
 
 	variables, err := client.AllVariables(user)
-	if err != nil {
-		t.Fatal(err)
-	}
+	fatalErr(t, err)
+
 	if len(variables) == 0 {
 		t.Fatal("No variables returned")
+	}
+}
+
+func fatalErr(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/eventqueue_test.go
+++ b/eventqueue_test.go
@@ -38,7 +38,7 @@ func TestEventQueue_QueueEvent_100_DropEvent(t *testing.T) {
 		if err != nil {
 			errored = true
 			log.Println(err)
-			return
+			break
 		}
 	}
 	if !errored {

--- a/localbucketing.go
+++ b/localbucketing.go
@@ -3,7 +3,6 @@ package devcycle
 import (
 	_ "embed"
 	"encoding/json"
-	"log"
 	"math/rand"
 	"sync"
 	"time"
@@ -74,7 +73,7 @@ func (d *DevCycleLocalBucketing) Initialize(sdkToken string, options *DVCOptions
 	}
 
 	err = d.wasmLinker.DefineFunc(d.wasmStore, "env", "console.log", func(messagePtr int32) {
-		log.Println(readAssemblyScriptString(messagePtr, d.wasmMemory, d.wasmStore))
+		printf(readAssemblyScriptString(messagePtr, d.wasmMemory, d.wasmStore))
 	})
 	if err != nil {
 		return
@@ -286,7 +285,7 @@ func (d *DevCycleLocalBucketing) GenerateBucketedConfigForUser(user string) (ret
 func (d *DevCycleLocalBucketing) StoreConfig(sdkKey, config string) error {
 	defer func() {
 		if err := recover(); err != nil {
-			log.Println("Failed to process config: ", err)
+			printf("Failed to process config: ", err)
 		}
 	}()
 	d.wasmMutex.Lock()
@@ -339,7 +338,7 @@ func (d *DevCycleLocalBucketing) SetClientCustomData(sdkKey string, customData s
 
 	_setClientCustomData := d.wasmInstance.GetExport(d.wasmStore, "setClientCustomData").Func()
 	_, err = _setClientCustomData.Call(d.wasmStore, sdkKeyAddr, customDataAddr)
-	
+
 	return err
 }
 

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,45 @@
+package devcycle
+
+import (
+	"log"
+	"strings"
+	"sync"
+)
+
+var (
+	globalLogger Logger = defaultLogger{}
+	globalLock   sync.Mutex
+)
+
+func SetLogger(log Logger) {
+	if log == nil {
+		panic("Can't set the logger to nil")
+	}
+
+	globalLock.Lock()
+	globalLogger = log
+	globalLock.Unlock()
+}
+
+func printf(format string, a ...any) {
+	globalLogger.Printf(format, a...)
+}
+
+type Logger interface {
+	Printf(format string, a ...any)
+}
+
+type defaultLogger struct{}
+
+func (defaultLogger) Printf(format string, a ...any) {
+	if !strings.HasSuffix(format, "\n") {
+		format += "\n"
+	}
+	log.Printf(format, a...)
+}
+
+type DiscardLogger struct{}
+
+func (DiscardLogger) Printf(_ string, _ ...any) {
+
+}


### PR DESCRIPTION
Not being able to configure this was making it such that our system had messages that weren't traceable to the service using them, or able to discard them. It was causing a lot of noise in our running system. 

I didn't really do much to look at the contents of the messages, just how they were sending. 

Also, I touched up some errors I saw around ineffectual assignment and some other small errors my linter caught. 