### PR TITLE
slim down some logging

### DIFF
--- a/configmanager.go
+++ b/configmanager.go
@@ -74,7 +74,6 @@ func (e *EnvironmentConfigManager) fetchConfig(retrying bool) error {
 		}
 		break
 	case statusCode == http.StatusNotModified:
-		debugf("Config not modified. Using cached config. %s\n", e.configETag)
 		break
 	case statusCode == http.StatusForbidden:
 		e.pollingStop <- true

--- a/eventqueue.go
+++ b/eventqueue.go
@@ -184,7 +184,7 @@ func (e *EventQueue) FlushEvents() (err error) {
 				errorf("failed to mark payload as success %s", err)
 				continue
 			}
-			infof("Flushed %d events\n", payload.EventCount)
+			debugf("Flushed %d events\n", payload.EventCount)
 		}
 	}
 	return err


### PR DESCRIPTION
I had these deployed in our staging environment and noticed that it was kinda noisy. 

re: flush - this is debug level info imho. 
re: unchanged - there is an existing 'updated the config' statement and error notifications