### PR TITLE
fix: log variable defaulted event when calling variable before init

### DIFF
--- a/eventqueue.go
+++ b/eventqueue.go
@@ -92,13 +92,13 @@ func (e *EventQueue) QueueEvent(user DVCUser, event DVCEvent) error {
 	return nil
 }
 
-func (e *EventQueue) QueueAggregateEvent(user BucketedUserConfig, event DVCEvent) error {
+func (e *EventQueue) QueueAggregateEvent(config BucketedUserConfig, event DVCEvent) error {
 	if q, err := e.checkEventQueueSize(); err != nil || q {
 		return errorf("Max event queue size reached, dropping aggregate event")
 	}
 	if !e.options.EnableCloudBucketing {
 		eventstring, err := json.Marshal(event)
-		err = e.localBucketing.queueAggregateEvent(string(eventstring), user)
+		err = e.localBucketing.queueAggregateEvent(string(eventstring), config)
 		return err
 	}
 	return nil

--- a/localbucketing.go
+++ b/localbucketing.go
@@ -19,21 +19,20 @@ var (
 )
 
 type DevCycleLocalBucketing struct {
-	wasm          []byte
-	wasmStore     *wasmtime.Store
-	wasmModule    *wasmtime.Module
-	wasmInstance  *wasmtime.Instance
-	wasmLinker    *wasmtime.Linker
-	wasiConfig    *wasmtime.WasiConfig
-	wasmMemory    *wasmtime.Memory
-	configManager *EnvironmentConfigManager
-	eventQueue    *EventQueue
-	sdkKey        string
-	options       *DVCOptions
-	cfg           *HTTPConfiguration
-	wasmMutex     sync.Mutex
-	flushMutex    sync.Mutex
-	sdkKeyAddr    int32
+	wasm         []byte
+	wasmStore    *wasmtime.Store
+	wasmModule   *wasmtime.Module
+	wasmInstance *wasmtime.Instance
+	wasmLinker   *wasmtime.Linker
+	wasiConfig   *wasmtime.WasiConfig
+	wasmMemory   *wasmtime.Memory
+	eventQueue   *EventQueue
+	sdkKey       string
+	options      *DVCOptions
+	cfg          *HTTPConfiguration
+	wasmMutex    sync.Mutex
+	flushMutex   sync.Mutex
+	sdkKeyAddr   int32
 }
 
 //go:embed bucketing-lib.release.wasm
@@ -107,8 +106,6 @@ func (d *DevCycleLocalBucketing) Initialize(sdkKey string, options *DVCOptions, 
 		return
 	}
 
-	d.configManager = &EnvironmentConfigManager{localBucketing: d}
-
 	platformData := PlatformData{}
 	platformData = *platformData.Default()
 	platformJSON, err := json.Marshal(platformData)
@@ -127,9 +124,6 @@ func (d *DevCycleLocalBucketing) Initialize(sdkKey string, options *DVCOptions, 
 	if err != nil {
 		return
 	}
-
-	err = d.configManager.Initialize(sdkKey, d)
-
 	return
 }
 
@@ -146,7 +140,7 @@ func (d *DevCycleLocalBucketing) setSDKKey(sdkKey string) (err error) {
 
 	d.sdkKey = sdkKey
 	d.sdkKeyAddr = addr
-	return nil
+	return
 }
 
 func (d *DevCycleLocalBucketing) initEventQueue(options string) (err error) {
@@ -275,12 +269,12 @@ func (d *DevCycleLocalBucketing) queueEvent(user, event string) (err error) {
 	return
 }
 
-func (d *DevCycleLocalBucketing) queueAggregateEvent(event string, user BucketedUserConfig) (err error) {
+func (d *DevCycleLocalBucketing) queueAggregateEvent(event string, config BucketedUserConfig) (err error) {
 	d.wasmMutex.Lock()
 	errorMessage = ""
 	defer d.wasmMutex.Unlock()
 
-	variationMap, err := json.Marshal(user.VariableVariationMap)
+	variationMap, err := json.Marshal(config.VariableVariationMap)
 	if err != nil {
 		return
 	}

--- a/localbucketing_test.go
+++ b/localbucketing_test.go
@@ -3,10 +3,8 @@ package devcycle
 import (
 	_ "embed"
 	"fmt"
-	"testing"
-	"time"
-
 	"github.com/jarcoal/httpmock"
+	"testing"
 )
 
 func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
@@ -158,71 +156,4 @@ func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B)
 			b.Fatal(err)
 		}
 	}
-}
-
-func TestEnvironmentConfigManager_Initialize(t *testing.T) {
-
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
-
-	var err error
-
-	localBucketing := DevCycleLocalBucketing{}
-
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{ConfigPollingIntervalMS: 500 * time.Millisecond}, NewConfiguration(&DVCOptions{}))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = localBucketing.configManager.Initialize(test_environmentKey, &localBucketing)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = localBucketing.SetPlatformData(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	localBucketing.configManager.cancel()
-	localBucketing.configManager.context.Done()
-	fmt.Println("done")
-}
-
-func TestEnvironmentConfigManager_LocalBucketing(t *testing.T) {
-
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
-
-	var err error
-
-	localBucketing := DevCycleLocalBucketing{}
-
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{ConfigPollingIntervalMS: 30 * time.Second}, NewConfiguration(&DVCOptions{}))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = localBucketing.configManager.Initialize(test_environmentKey, &localBucketing)
-	if err != nil {
-		t.Fatal(err)
-	}
-	time.Sleep(1 * time.Second)
-	err = localBucketing.SetPlatformData(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-	user, err := localBucketing.GenerateBucketedConfigForUser(
-		`{"user_id": "j_test", "platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if user.Project.Id != "6216420c2ea68943c8833c09" {
-		t.Fatalf("Project does not match. %s, %s", user.Project.Id, "6216420c2ea68943c8833c09")
-	}
-
-	localBucketing.configManager.cancel()
-	localBucketing.configManager.context.Done()
-	fmt.Println("done")
 }

--- a/logger.go
+++ b/logger.go
@@ -62,14 +62,14 @@ func (defaultLogger) Debugf(format string, a ...any) {
 	if !strings.HasSuffix(format, "\n") {
 		format += "\n"
 	}
-	log.Printf("DEBUG:"+format, a...)
+	log.Printf("DEBUG: "+format, a...)
 }
 
 func (defaultLogger) Infof(format string, a ...any) {
 	if !strings.HasSuffix(format, "\n") {
 		format += "\n"
 	}
-	log.Printf("INFO:"+format, a...)
+	log.Printf("INFO: "+format, a...)
 }
 
 func (defaultLogger) Printf(format string, a ...any) {
@@ -83,14 +83,14 @@ func (defaultLogger) Warnf(format string, a ...any) {
 	if !strings.HasSuffix(format, "\n") {
 		format += "\n"
 	}
-	log.Printf("WARN:"+format, a...)
+	log.Printf("WARN: "+format, a...)
 }
 
 func (defaultLogger) Errorf(format string, a ...any) error {
 	if !strings.HasSuffix(format, "\n") {
 		format += "\n"
 	}
-	log.Printf("ERROR:"+format, a...)
+	log.Printf("ERROR: "+format, a...)
 	return errors.New(fmt.Sprintf(format, a...))
 }
 


### PR DESCRIPTION
- if calling `variable` before init, log a `aggVariableDefaulted` event
- change deferred initialization to only defer the actual config HTTP call, but synchronously instantiate everything else.