### PR TITLE
refactor local bucketing module to remove ownership over event queue

### DIFF
--- a/localbucketing.go
+++ b/localbucketing.go
@@ -34,10 +34,8 @@ type DevCycleLocalBucketing struct {
 	wasmLinker   *wasmtime.Linker
 	wasiConfig   *wasmtime.WasiConfig
 	wasmMemory   *wasmtime.Memory
-	eventQueue   *EventQueue
 	sdkKey       string
 	options      *DVCOptions
-	cfg          *HTTPConfiguration
 	wasmMutex    sync.Mutex
 	flushMutex   sync.Mutex
 	sdkKeyAddr   int32
@@ -67,13 +65,11 @@ type DevCycleLocalBucketing struct {
 //go:embed bucketing-lib.release.wasm
 var wasmBinary []byte
 
-func (d *DevCycleLocalBucketing) Initialize(sdkKey string, options *DVCOptions, cfg *HTTPConfiguration) (err error) {
+func (d *DevCycleLocalBucketing) Initialize(sdkKey string, options *DVCOptions) (err error) {
 	options.CheckDefaults()
 
 	d.options = options
-	d.cfg = cfg
 	d.wasm = wasmBinary
-	d.eventQueue = &EventQueue{}
 	d.wasiConfig = wasmtime.NewWasiConfig()
 	d.wasiConfig.InheritEnv()
 	d.wasiConfig.InheritStderr()
@@ -178,17 +174,6 @@ func (d *DevCycleLocalBucketing) Initialize(sdkKey string, options *DVCOptions, 
 		return
 	}
 	err = d.SetPlatformData(string(platformJSON))
-	if err != nil {
-		return
-	}
-
-	if err != nil {
-		return
-	}
-	err = d.eventQueue.initialize(options, d)
-	if err != nil {
-		return
-	}
 
 	return
 }

--- a/localbucketing_test.go
+++ b/localbucketing_test.go
@@ -13,7 +13,7 @@ func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
 	httpConfigMock(200)
 	localBucketing := DevCycleLocalBucketing{}
 	var err error
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{}, NewConfiguration(&DVCOptions{}))
+	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func BenchmarkDevCycleLocalBucketing_Initialize(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		localBucketing := DevCycleLocalBucketing{}
 		var err error
-		err = localBucketing.Initialize(test_environmentKey, &DVCOptions{}, NewConfiguration(&DVCOptions{}))
+		err = localBucketing.Initialize(test_environmentKey, &DVCOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -40,7 +40,7 @@ func TestDevCycleLocalBucketing_GenerateBucketedConfigForUser(t *testing.T) {
 	localBucketing := DevCycleLocalBucketing{}
 	var err error
 
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{}, NewConfiguration(&DVCOptions{}))
+	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestDevCycleLocalBucketing_StoreConfig(t *testing.T) {
 	localBucketing := DevCycleLocalBucketing{}
 	var err error
 
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{}, NewConfiguration(&DVCOptions{}))
+	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func BenchmarkDevCycleLocalBucketing_StoreConfig(b *testing.B) {
 	localBucketing := DevCycleLocalBucketing{}
 	var err error
 
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{}, NewConfiguration(&DVCOptions{}))
+	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestDevCycleLocalBucketing_SetPlatformData(t *testing.T) {
 	localBucketing := DevCycleLocalBucketing{}
 	var err error
 
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{}, NewConfiguration(&DVCOptions{}))
+	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B)
 	localBucketing := DevCycleLocalBucketing{}
 	var err error
 
-	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{}, NewConfiguration(&DVCOptions{}))
+	err = localBucketing.Initialize(test_environmentKey, &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
Isolate the local bucketing module more by removing its ownership over the event queue. this should help reorganize things for thread pooling