### PR TITLE
additional safety around constructing new objects for pool

### DIFF
--- a/bucketing_pool.go
+++ b/bucketing_pool.go
@@ -9,13 +9,15 @@ import (
 )
 
 type BucketingPool struct {
-	pool1         *pool.ObjectPool
-	pool2         *pool.ObjectPool
-	currentPool   atomic.Pointer[pool.ObjectPool]
-	poolSwapMutex sync.Mutex
-	ctx           context.Context
-	factory       *BucketingPoolFactory
-	closed        atomic.Bool
+	pool1            *pool.ObjectPool
+	pool2            *pool.ObjectPool
+	currentPool      atomic.Pointer[pool.ObjectPool]
+	poolSwapMutex    sync.Mutex
+	ctx              context.Context
+	factory          *BucketingPoolFactory
+	closed           atomic.Bool
+	configData       *[]byte
+	clientCustomData *[]byte
 }
 
 func NewBucketingPool(ctx context.Context, wasmMain *WASMMain, sdkKey string, options *DVCOptions) (*BucketingPool, error) {
@@ -142,6 +144,7 @@ func (p *BucketingPool) SetConfig(config []byte) error {
 		return errorf("Cannot set config on closed pool")
 	}
 	debugf("Setting config on all workers")
+	p.configData = &config
 	return p.ProcessAll("SetConfig", func(object *BucketingPoolObject) error {
 		return object.StoreConfig(&config)
 	})
@@ -152,6 +155,7 @@ func (p *BucketingPool) SetClientCustomData(customData []byte) error {
 		return errorf("Cannot set client custom data on closed pool")
 	}
 	debugf("Setting client custom data on all workers")
+	p.clientCustomData = &customData
 	return p.ProcessAll("SetClientCustomData", func(object *BucketingPoolObject) error {
 		return object.SetClientCustomData(&customData)
 	})

--- a/bucketing_pool_factory.go
+++ b/bucketing_pool_factory.go
@@ -27,6 +27,19 @@ func (f *BucketingPoolFactory) MakeObject(ctx context.Context) (*pool.PooledObje
 	if err != nil {
 		return nil, err
 	}
+	if f.pool.configData != nil {
+		err = bucketing.StoreConfig(f.pool.configData)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if f.pool.clientCustomData != nil {
+		err = bucketing.SetClientCustomData(f.pool.clientCustomData)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	return pool.NewPooledObject(
 			bucketing),


### PR DESCRIPTION
Update bucketing object factory to make sure that if AddObject is called sometime after initialization, the object that is created will be initialized with the last known config and client custom data. 

AddObject currently shouldn't be called after initialization, but the pool will automatically call it if an object is destroyed or removed from the pool for any reason.