### PR TITLE
DVC-6813: Retry config fetching on network error

### DIFF
--- a/bucketing_pool.go
+++ b/bucketing_pool.go
@@ -2,10 +2,11 @@ package devcycle
 
 import (
 	"context"
-	"github.com/devcyclehq/go-server-sdk/v2/proto"
-	pool "github.com/jolestar/go-commons-pool/v2"
 	"sync"
 	"sync/atomic"
+
+	"github.com/devcyclehq/go-server-sdk/v2/proto"
+	pool "github.com/jolestar/go-commons-pool/v2"
 )
 
 type BucketingPool struct {
@@ -137,12 +138,12 @@ func (p *BucketingPool) ProcessAll(
 	return err
 }
 
-func (p *BucketingPool) SetConfig(config []byte) error {
+func (p *BucketingPool) StoreConfig(config []byte) error {
 	if p.closed.Load() {
 		return errorf("Cannot set config on closed pool")
 	}
 	debugf("Setting config on all workers")
-	return p.ProcessAll("SetConfig", func(object *BucketingPoolObject) error {
+	return p.ProcessAll("StoreConfig", func(object *BucketingPoolObject) error {
 		return object.StoreConfig(&config)
 	})
 }

--- a/client.go
+++ b/client.go
@@ -100,8 +100,8 @@ func setLBClient(sdkKey string, options *DVCOptions, c *DVCClient) error {
 		return err
 	}
 
-	c.configManager = &EnvironmentConfigManager{localBucketing: localBucketing}
-	err = c.configManager.Initialize(sdkKey, localBucketing, c.bucketingObjectPool, c.cfg)
+	c.configManager = NewEnvironmentConfigManager(sdkKey, localBucketing, c.bucketingObjectPool, options, c.cfg)
+	c.configManager.StartPolling(options.ConfigPollingIntervalMS)
 
 	if err != nil {
 		return err

--- a/configmanager.go
+++ b/configmanager.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const CONFIG_RETRIES = 3
+const CONFIG_RETRIES = 1
 
 type ConfigReceiver interface {
 	StoreConfig([]byte) error

--- a/configmanager.go
+++ b/configmanager.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const CONFIG_RETRIES = 1
+const CONFIG_RETRIES = 3
 
 type ConfigReceiver interface {
 	StoreConfig([]byte) error

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -1,0 +1,74 @@
+package devcycle
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+)
+
+type recordingConfigReceiver struct {
+	configureCount int
+}
+
+func (r *recordingConfigReceiver) StoreConfig([]byte) error {
+	r.configureCount++
+	return nil
+}
+
+func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "https://config-cdn.devcycle.com/config/v1/server/"+test_environmentKey+".json",
+		func(req *http.Request) (*http.Response, error) {
+			resp := httpmock.NewStringResponse(200, test_config)
+			resp.Header.Set("Etag", "TESTING")
+			return resp, nil
+		},
+	)
+
+	localBucketing, bucketingPool := &recordingConfigReceiver{}, &recordingConfigReceiver{}
+	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, bucketingPool, test_options, NewConfiguration(test_options))
+
+	err := manager.initialFetch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if localBucketing.configureCount != 1 {
+		t.Fatal("localBucketing.configureCount != 1")
+	}
+	if bucketingPool.configureCount != 1 {
+		t.Fatal("bucketingPool.configureCount != 1")
+	}
+	if !manager.hasConfig.Load() {
+		t.Fatal("cm.hasConfig != true")
+	}
+	if manager.configETag != "TESTING" {
+		t.Fatal("cm.configEtag != TESTING")
+	}
+}
+
+func TestEnvironmentConfigManager_fetchConfig_retries500(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	successResponse := httpConfigMock(200)
+	errorResponse := httpmock.NewStringResponder(http.StatusInternalServerError, "Internal Server Error")
+
+	httpmock.RegisterResponder("GET", "https://config-cdn.devcycle.com/config/v1/server/"+test_environmentKey+".json",
+		errorResponse.Then(successResponse),
+	)
+
+	localBucketing, bucketingPool := &recordingConfigReceiver{}, &recordingConfigReceiver{}
+	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, bucketingPool, test_options, NewConfiguration(test_options))
+
+	err := manager.initialFetch()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !manager.hasConfig.Load() {
+		t.Fatal("cm.hasConfig != true")
+	}
+}


### PR DESCRIPTION
This PR restructures EnvironmentConfigManager to make it a bit easier to test, then expands the criteria under which we retry a config request.

Previously we only retried once for 500-level HTTP status codes, now we also retry on connection error, DNS error, etc. and unexpected HTTP statuses. When the retries are exhausted, we still return the error to the client, unless it's a 500 status.