### PR TITLE
Fix WASM error when Track called before config loads

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"reflect"
 	"runtime"
@@ -271,6 +272,29 @@ func TestDVCClient_TrackLocal_QueueEvent(t *testing.T) {
 	dvcOptions := DVCOptions{ConfigPollingIntervalMS: 10 * time.Second}
 
 	c, err := NewDVCClient(test_environmentKey, &dvcOptions)
+
+	track, err := c.Track(DVCUser{UserId: "j_test", DeviceModel: "testing"}, DVCEvent{
+		Target:      "customEvent",
+		Value:       0,
+		Type_:       "someType",
+		FeatureVars: nil,
+		MetaData:    nil,
+	})
+	fatalErr(t, err)
+
+	fmt.Println(track)
+}
+
+func TestDVCClient_TrackLocal_QueueEventBeforeConfig(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	// Config will fail to load on HTTP 500 after several retries without an error
+	httpConfigMock(http.StatusInternalServerError)
+	dvcOptions := DVCOptions{ConfigPollingIntervalMS: 10 * time.Second}
+
+	c, err := NewDVCClient(test_environmentKey, &dvcOptions)
+	fatalErr(t, err)
 
 	track, err := c.Track(DVCUser{UserId: "j_test", DeviceModel: "testing"}, DVCEvent{
 		Target:      "customEvent",


### PR DESCRIPTION
I noticed this error while testing config loading. The current WASM appears to require config to be loaded in order to track events. We were only gating these calls on the SDK being initialized, but not the config loading successfully.

```
Error Message calling queueEvent: err: [error while executing at wasm backtrace:    0: 0xe756 - <unknown>!<wasm function 172>    1: 0x29805 - <unknown>!<wasm function 466>Caused by:    wasm trap: wasm `unreachable` instruction executed] errorMessage:[WASM Error: Config data is not set. at assembly/managers/configDataManager.ts:11:9]
```