### PR TITLE
DVC-6664 - validate client options

### DIFF
--- a/client.go
+++ b/client.go
@@ -124,11 +124,6 @@ func NewDVCClient(sdkKey string, options *DVCOptions) (*DVCClient, error) {
 
 	options.CheckDefaults()
 
-	err := options.Validate()
-	if err != nil {
-		return nil, err
-	}
-
 	c := &DVCClient{sdkKey: sdkKey}
 	c.cfg = cfg
 	c.ctx = context.Background()
@@ -157,6 +152,10 @@ func NewDVCClient(sdkKey string, options *DVCOptions) (*DVCClient, error) {
 			c.handleInitialization()
 			return c, err
 		}
+	} else if c.DevCycleOptions.OnInitializedChannel != nil && c.DevCycleOptions.EnableCloudBucketing {
+		go func() {
+			c.DevCycleOptions.OnInitializedChannel <- true
+		}()
 	}
 	return c, nil
 }

--- a/client.go
+++ b/client.go
@@ -152,7 +152,7 @@ func NewDVCClient(sdkKey string, options *DVCOptions) (*DVCClient, error) {
 			c.handleInitialization()
 			return c, err
 		}
-	} else if c.DevCycleOptions.OnInitializedChannel != nil && c.DevCycleOptions.EnableCloudBucketing {
+	} else if c.DevCycleOptions.OnInitializedChannel != nil {
 		go func() {
 			c.DevCycleOptions.OnInitializedChannel <- true
 		}()

--- a/client.go
+++ b/client.go
@@ -124,6 +124,11 @@ func NewDVCClient(sdkKey string, options *DVCOptions) (*DVCClient, error) {
 
 	options.CheckDefaults()
 
+	err := options.Validate()
+	if err != nil {
+		return nil, err
+	}
+
 	c := &DVCClient{sdkKey: sdkKey}
 	c.cfg = cfg
 	c.ctx = context.Background()

--- a/client_test.go
+++ b/client_test.go
@@ -369,6 +369,10 @@ func TestDVCClient_Validate_OnInitializedChannel_EnableCloudBucketing_Options(t 
 		t.Fatal("Expected isInitialized to be true")
 	}
 
+	if !c.hasConfig() {
+		t.Fatal("Expected config to be loaded")
+	}
+
 	dvcOptions = DVCOptions{OnInitializedChannel: nil, EnableCloudBucketing: true}
 	c, err = NewDVCClient(test_environmentKey, &dvcOptions)
 	fatalErr(t, err)
@@ -384,6 +388,10 @@ func TestDVCClient_Validate_OnInitializedChannel_EnableCloudBucketing_Options(t 
 
 	if !c.isInitialized {
 		t.Fatal("Expected isInitialized to be true")
+	}
+
+	if !c.hasConfig() {
+		t.Fatal("Expected config to be loaded")
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -345,28 +345,46 @@ func TestDVCClient_Validate_OnInitializedChannel_EnableCloudBucketing_Options(t 
 
 	// Try each of the combos to make sure they all act as expected and don't hang
 	dvcOptions := DVCOptions{OnInitializedChannel: onInitialized, EnableCloudBucketing: true}
-	_, err := NewDVCClient(test_environmentKey, &dvcOptions)
+	c, err := NewDVCClient(test_environmentKey, &dvcOptions)
 	fatalErr(t, err)
 	val := <-onInitialized
 	if !val {
 		t.Fatal("Expected true from onInitialized channel")
 	}
 
+	if c.isInitialized {
+		// isInitialized is only relevant when using Local Bucketing
+		t.Fatal("Expected isInitialized to be false")
+	}
+
 	dvcOptions = DVCOptions{OnInitializedChannel: onInitialized, EnableCloudBucketing: false}
-	_, err = NewDVCClient(test_environmentKey, &dvcOptions)
+	c, err = NewDVCClient(test_environmentKey, &dvcOptions)
 	fatalErr(t, err)
 	val = <-onInitialized
 	if !val {
 		t.Fatal("Expected true from onInitialized channel")
 	}
 
+	if !c.isInitialized {
+		t.Fatal("Expected isInitialized to be true")
+	}
+
 	dvcOptions = DVCOptions{OnInitializedChannel: nil, EnableCloudBucketing: true}
-	_, err = NewDVCClient(test_environmentKey, &dvcOptions)
+	c, err = NewDVCClient(test_environmentKey, &dvcOptions)
 	fatalErr(t, err)
 
+	if c.isInitialized {
+		// isInitialized is only relevant when using Local Bucketing
+		t.Fatal("Expected isInitialized to be false")
+	}
+
 	dvcOptions = DVCOptions{OnInitializedChannel: nil, EnableCloudBucketing: false}
-	_, err = NewDVCClient(test_environmentKey, &dvcOptions)
+	c, err = NewDVCClient(test_environmentKey, &dvcOptions)
 	fatalErr(t, err)
+
+	if !c.isInitialized {
+		t.Fatal("Expected isInitialized to be true")
+	}
 }
 
 func fatalErr(t *testing.T, err error) {

--- a/client_test.go
+++ b/client_test.go
@@ -336,6 +336,21 @@ func TestProduction_Local(t *testing.T) {
 	}
 }
 
+func TestDVCClient_InvalidOptions(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	httpConfigMock(200)
+
+	onInitialized := make(chan bool)
+	dvcOptions := DVCOptions{OnInitializedChannel: onInitialized, EnableCloudBucketing: true}
+
+	_, err := NewDVCClient(test_environmentKey, &dvcOptions)
+
+	if err == nil {
+		t.Fatal(t, "Expected error from invalid options")
+	}
+}
+
 func fatalErr(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -336,19 +336,37 @@ func TestProduction_Local(t *testing.T) {
 	}
 }
 
-func TestDVCClient_InvalidOptions(t *testing.T) {
+func TestDVCClient_Validate_OnInitializedChannel_EnableCloudBucketing_Options(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	httpConfigMock(200)
 
 	onInitialized := make(chan bool)
+
+	// Try each of the combos to make sure they all act as expected and don't hang
 	dvcOptions := DVCOptions{OnInitializedChannel: onInitialized, EnableCloudBucketing: true}
-
 	_, err := NewDVCClient(test_environmentKey, &dvcOptions)
-
-	if err == nil {
-		t.Fatal(t, "Expected error from invalid options")
+	fatalErr(t, err)
+	val := <-onInitialized
+	if !val {
+		t.Fatal("Expected true from onInitialized channel")
 	}
+
+	dvcOptions = DVCOptions{OnInitializedChannel: onInitialized, EnableCloudBucketing: false}
+	_, err = NewDVCClient(test_environmentKey, &dvcOptions)
+	fatalErr(t, err)
+	val = <-onInitialized
+	if !val {
+		t.Fatal("Expected true from onInitialized channel")
+	}
+
+	dvcOptions = DVCOptions{OnInitializedChannel: nil, EnableCloudBucketing: true}
+	_, err = NewDVCClient(test_environmentKey, &dvcOptions)
+	fatalErr(t, err)
+
+	dvcOptions = DVCOptions{OnInitializedChannel: nil, EnableCloudBucketing: false}
+	_, err = NewDVCClient(test_environmentKey, &dvcOptions)
+	fatalErr(t, err)
 }
 
 func fatalErr(t *testing.T, err error) {

--- a/configuration.go
+++ b/configuration.go
@@ -121,6 +121,15 @@ func (o *DVCOptions) CheckDefaults() {
 	}
 }
 
+// Ensure the options are in a non-conflicted state
+func (o *DVCOptions) Validate() error {
+	// OnInitialization is not triggered when cloud bucketing is enabled
+	if o.EnableCloudBucketing && o.OnInitializedChannel != nil {
+		return errorf("OnInitializedChannel cannot be set when EnableCloudBucketing is true")
+	}
+	return nil
+}
+
 type HTTPConfiguration struct {
 	BasePath          string            `json:"basePath,omitempty"`
 	ConfigCDNBasePath string            `json:"configCDNBasePath,omitempty"`

--- a/configuration.go
+++ b/configuration.go
@@ -121,15 +121,6 @@ func (o *DVCOptions) CheckDefaults() {
 	}
 }
 
-// Ensure the options are in a non-conflicted state
-func (o *DVCOptions) Validate() error {
-	// OnInitialization is not triggered when cloud bucketing is enabled
-	if o.EnableCloudBucketing && o.OnInitializedChannel != nil {
-		return errorf("OnInitializedChannel cannot be set when EnableCloudBucketing is true")
-	}
-	return nil
-}
-
 type HTTPConfiguration struct {
 	BasePath          string            `json:"basePath,omitempty"`
 	ConfigCDNBasePath string            `json:"configCDNBasePath,omitempty"`


### PR DESCRIPTION
Added validation to the options to throw an error when combinations of options will result in the client being in an unsafe state. In this case if you set an OnInitialized channel and EnableCloudBucketing=true, then listen on the channel it will hang indefinitely