### PR TITLE
DVC-6656 Add benchmark GitHub action

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,39 @@
+name: Benchmark SDK
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v1
+      # Run benchmark with `go test -bench` and stores the output to a file
+      - name: Run benchmark
+        run: go test -bench=. -run=^# -benchDisableLogs | tee output.txt
+      # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v1
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+      # Run `github-action-benchmark` action
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          # What benchmark tool the output.txt came from
+          tool: 'go'
+          # Where the output from the benchmark tool is stored
+          output-file-path: output.txt
+          # Where the previous data file is stored
+          external-data-json-path: ./cache/benchmark-data.json
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          # Enable Job Summary for PRs
+          summary-always: true
+          comment-on-alert: true
+
+      # Upload the updated cache file for the next job by actions/cache

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,6 +35,5 @@ jobs:
           fail-on-alert: true
           # Enable Job Summary for PRs
           summary-always: true
-          comment-on-alert: true
 
       # Upload the updated cache file for the next job by actions/cache

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,8 +29,8 @@ jobs:
           external-data-json-path: ./cache/benchmark-data.json
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-alert: true
-          fail-threshold: 110%
           comment-on-alert: true
-          alert-threshold: 110%
+          alert-threshold: 125%
+          fail-on-alert: true
+          fail-threshold: 150%
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,4 +1,4 @@
-name: Benchmark SDK
+name: Benchmark
 on:
   push:
     branches: [ main ]
@@ -7,38 +7,30 @@ on:
 
 jobs:
   benchmark:
-    name: Performance regression check
+    name: Performance Regression Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      # Run benchmark with `go test -bench` and stores the output to a file
       - name: Run benchmark
         run: go test -bench=. -run=^# -benchDisableLogs | tee bench_output.txt
-      # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
         uses: actions/cache@v3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark
-      # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          # What benchmark tool the output.txt came from
           tool: 'go'
-          # Where the output from the benchmark tool is stored
           output-file-path: bench_output.txt
-          # Where the previous data file is stored
           external-data-json-path: ./cache/benchmark-data.json
           summary-always: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-always: true
           fail-on-alert: true
-          fail-threshold: 150%
+          fail-threshold: 110%
           comment-on-alert: true
-          alert-threshold: 150%
+          alert-threshold: 110%
 
-      # Upload the updated cache file for the next job by actions/cache

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: 1.19
       - name: Run benchmark
-        run: go test -bench=. -run=^# -benchDisableLogs | tee bench_output.txt
+        run: go test -bench=^BenchmarkDVCClient_Variable -run=^# -benchDisableLogs | tee bench_output.txt
       - name: Download previous benchmark data
         uses: actions/cache@v3
         with:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,9 @@
 name: Benchmark SDK
 on:
   push:
-    branches:
-      - master
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   benchmark:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -10,14 +10,16 @@ jobs:
     name: Performance regression check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
       # Run benchmark with `go test -bench` and stores the output to a file
       - name: Run benchmark
         run: go test -bench=. -run=^# -benchDisableLogs | tee output.txt
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ./cache
           key: ${{ runner.os }}-benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -37,8 +37,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-always: true
           fail-on-alert: true
-          fail-threshold: 25%
+          fail-threshold: 150%
           comment-on-alert: true
-          alert-threshold: 25%
+          alert-threshold: 150%
 
       # Upload the updated cache file for the next job by actions/cache

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,7 +16,7 @@ jobs:
           go-version: 1.19
       # Run benchmark with `go test -bench` and stores the output to a file
       - name: Run benchmark
-        run: go test -bench=. -run=^# -benchDisableLogs | tee output.txt
+        run: go test -bench=. -run=^# -benchDisableLogs | tee bench_output.txt
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
         uses: actions/cache@v3
@@ -30,12 +30,15 @@ jobs:
           # What benchmark tool the output.txt came from
           tool: 'go'
           # Where the output from the benchmark tool is stored
-          output-file-path: output.txt
+          output-file-path: bench_output.txt
           # Where the previous data file is stored
           external-data-json-path: ./cache/benchmark-data.json
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
-          # Enable Job Summary for PRs
           summary-always: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-always: true
+          fail-on-alert: true
+          fail-threshold: 25%
+          comment-on-alert: true
+          alert-threshold: 25%
 
       # Upload the updated cache file for the next job by actions/cache


### PR DESCRIPTION
A new action that will run the benchmark tests for variables and use the 3rd party `github-action-benchmark` action compare benchmarks against the previous cached version and report errors when the variable performance is off by 25% or higher

The plugin sets the benchmark results as comments on the commit that trigger the warning/error. 

