### PR TITLE
Extract wasm logic from DVCClient into a new wrapper

### DIFF
--- a/bucketing_pool_object.go
+++ b/bucketing_pool_object.go
@@ -11,14 +11,14 @@ var (
 )
 
 type BucketingPoolObject struct {
-	localBucketing   *DevCycleLocalBucketing
+	localBucketing   *WASMLocalBucketingClient
 	id               int32
 	configData       *[]byte
 	clientCustomData *[]byte
 }
 
 func (o *BucketingPoolObject) Initialize(wasmMain *WASMMain, sdkKey string, options *DVCOptions) (err error) {
-	o.localBucketing = &DevCycleLocalBucketing{}
+	o.localBucketing = &WASMLocalBucketingClient{}
 	err = o.localBucketing.Initialize(wasmMain, sdkKey, options)
 
 	if err != nil {

--- a/client_native.go
+++ b/client_native.go
@@ -1,3 +1,0 @@
-//go:build native_bucketing
-
-package devcycle

--- a/client_wasm.go
+++ b/client_wasm.go
@@ -1,3 +1,0 @@
-//go:build !native_bucketing
-
-package devcycle

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -23,8 +23,8 @@ func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
 
 	httpConfigMock(200)
 
-	localBucketing, bucketingPool := &recordingConfigReceiver{}, &recordingConfigReceiver{}
-	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, bucketingPool, test_options, NewConfiguration(test_options))
+	localBucketing := &recordingConfigReceiver{}
+	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, test_options, NewConfiguration(test_options))
 
 	err := manager.initialFetch()
 	if err != nil {
@@ -33,9 +33,6 @@ func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
 
 	if localBucketing.configureCount != 1 {
 		t.Fatal("localBucketing.configureCount != 1")
-	}
-	if bucketingPool.configureCount != 1 {
-		t.Fatal("bucketingPool.configureCount != 1")
 	}
 	if !manager.hasConfig.Load() {
 		t.Fatal("cm.hasConfig != true")
@@ -55,8 +52,8 @@ func TestEnvironmentConfigManager_fetchConfig_retries500(t *testing.T) {
 		errorResponseChain(error500Response, CONFIG_RETRIES),
 	)
 
-	localBucketing, bucketingPool := &recordingConfigReceiver{}, &recordingConfigReceiver{}
-	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, bucketingPool, test_options, NewConfiguration(test_options))
+	localBucketing := &recordingConfigReceiver{}
+	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, test_options, NewConfiguration(test_options))
 
 	err := manager.initialFetch()
 	if err != nil {
@@ -77,8 +74,8 @@ func TestEnvironmentConfigManager_fetchConfig_retries_errors(t *testing.T) {
 		errorResponseChain(connectionErrorResponse, CONFIG_RETRIES),
 	)
 
-	localBucketing, bucketingPool := &recordingConfigReceiver{}, &recordingConfigReceiver{}
-	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, bucketingPool, test_options, NewConfiguration(test_options))
+	localBucketing := &recordingConfigReceiver{}
+	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, test_options, NewConfiguration(test_options))
 
 	err := manager.initialFetch()
 	if err != nil {
@@ -99,8 +96,8 @@ func TestEnvironmentConfigManager_fetchConfig_returns_errors(t *testing.T) {
 		errorResponseChain(connectionErrorResponse, CONFIG_RETRIES+1),
 	)
 
-	localBucketing, bucketingPool := &recordingConfigReceiver{}, &recordingConfigReceiver{}
-	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, bucketingPool, test_options, NewConfiguration(test_options))
+	localBucketing := &recordingConfigReceiver{}
+	manager := NewEnvironmentConfigManager(test_environmentKey, localBucketing, test_options, NewConfiguration(test_options))
 
 	err := manager.initialFetch()
 	if err == nil {

--- a/eventqueue.go
+++ b/eventqueue.go
@@ -12,7 +12,7 @@ import (
 )
 
 type EventQueue struct {
-	localBucketing      *DevCycleLocalBucketing
+	localBucketing      *WASMLocalBucketingClient
 	options             *DVCOptions
 	cfg                 *HTTPConfiguration
 	context             context.Context
@@ -29,7 +29,12 @@ type FlushResult struct {
 	FailureWithRetryPayloads []string
 }
 
-func (e *EventQueue) initialize(options *DVCOptions, localBucketing *DevCycleLocalBucketing, bucketingObjectPool *BucketingPool, cfg *HTTPConfiguration) (err error) {
+type PayloadsAndChannel struct {
+	payloads []FlushPayload
+	channel  *chan *FlushResult
+}
+
+func (e *EventQueue) initialize(options *DVCOptions, localBucketing *WASMLocalBucketingClient, bucketingObjectPool *BucketingPool, cfg *HTTPConfiguration) (err error) {
 	e.context = context.Background()
 	e.cfg = cfg
 	e.options = options

--- a/localbucketing_test.go
+++ b/localbucketing_test.go
@@ -3,9 +3,10 @@ package devcycle
 import (
 	_ "embed"
 	"fmt"
+	"testing"
+
 	"github.com/devcyclehq/go-server-sdk/v2/proto"
 	"github.com/jarcoal/httpmock"
-	"testing"
 )
 
 func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
@@ -16,7 +17,7 @@ func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -30,7 +31,7 @@ func BenchmarkDevCycleLocalBucketing_Initialize(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		wasmMain := WASMMain{}
 		err := wasmMain.Initialize(nil)
-		localBucketing := DevCycleLocalBucketing{}
+		localBucketing := WASMLocalBucketingClient{}
 		err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 		if err != nil {
 			b.Fatal(err)
@@ -44,7 +45,7 @@ func TestDevCycleLocalBucketing_GenerateBucketedConfigForUser(t *testing.T) {
 	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -80,7 +81,7 @@ func TestDevCycleLocalBucketing_StoreConfig(t *testing.T) {
 	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 
 	if err != nil {
@@ -99,7 +100,7 @@ func BenchmarkDevCycleLocalBucketing_StoreConfig(b *testing.B) {
 	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(&DVCOptions{})
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
@@ -123,7 +124,7 @@ func TestDevCycleLocalBucketing_SetPlatformData(t *testing.T) {
 
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -143,7 +144,7 @@ func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B)
 
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
@@ -176,7 +177,7 @@ func BenchmarkDevCycleLocalBucketing_VariableForUser_PB(b *testing.B) {
 
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{
 		AdvancedOptions: AdvancedOptions{
@@ -241,7 +242,7 @@ func TestDevCycleLocalBucketing_newAssemblyScriptNoPoolByteArray(t *testing.T) {
 	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
-	localBucketing := DevCycleLocalBucketing{}
+	localBucketing := WASMLocalBucketingClient{}
 	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
 
 	if err != nil {

--- a/native_bucketing/bucketing.go
+++ b/native_bucketing/bucketing.go
@@ -159,7 +159,6 @@ func bucketUserForVariation(feature *Feature, hashes TargetAndHashes) (Variation
 	}
 	return Variation{}, fmt.Errorf("config missing variation %s", variationId)
 }
-
 func _generateBucketedConfig(config ConfigBody, user DVCPopulatedUser, clientCustomData map[string]interface{}) (BucketedUserConfig, error) {
 	variableMap := make(map[string]SDKVariable)
 	featureKeyMap := make(map[string]SDKFeature)


### PR DESCRIPTION
This refactors the DVCClient so that the WASM and object pool related code is now contained inside a new wrapper type, WASMLocalBucketing.

