### PR TITLE
DEV-7024: Fix issues with SetPlatformData in native bucketing

### DIFF
--- a/api/model_platformdata.go
+++ b/api/model_platformdata.go
@@ -1,10 +1,5 @@
 package api
 
-import (
-	"os"
-	"runtime"
-)
-
 type PlatformData struct {
 	SdkType         string `json:"sdkType"`
 	SdkVersion      string `json:"sdkVersion"`
@@ -12,13 +7,4 @@ type PlatformData struct {
 	DeviceModel     string `json:"deviceModel"`
 	Platform        string `json:"platform"`
 	Hostname        string `json:"hostname"`
-}
-
-func (pd *PlatformData) Default(sdkVersion string) *PlatformData {
-	pd.Platform = "Go"
-	pd.SdkType = "server"
-	pd.PlatformVersion = runtime.Version()
-	pd.Hostname, _ = os.Hostname()
-	pd.SdkVersion = sdkVersion
-	return pd
 }

--- a/api/model_platformdata.go
+++ b/api/model_platformdata.go
@@ -14,7 +14,6 @@ type PlatformData struct {
 	Hostname        string `json:"hostname"`
 }
 
-// TODO: Set SDK version
 func (pd *PlatformData) Default(sdkVersion string) *PlatformData {
 	pd.Platform = "Go"
 	pd.SdkType = "server"

--- a/api/model_user_data.go
+++ b/api/model_user_data.go
@@ -14,8 +14,6 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-var platformData = (&PlatformData{}).Default(VERSION)
-
 type DVCUser struct {
 	// Unique id to identify the user
 	UserId string `json:"user_id"`
@@ -48,7 +46,7 @@ type DVCPopulatedUser struct {
 	CreatedDate time.Time `json:"createdDate,omitempty"`
 }
 
-func (user DVCUser) GetPopulatedUser() DVCPopulatedUser {
+func (user DVCUser) GetPopulatedUser(platformData *PlatformData) DVCPopulatedUser {
 	return DVCPopulatedUser{
 		user,
 		platformData,

--- a/api/version.go
+++ b/api/version.go
@@ -1,3 +1,0 @@
-package api
-
-const VERSION = "2.9.4"

--- a/bucketing_pool.go
+++ b/bucketing_pool.go
@@ -19,7 +19,7 @@ type BucketingPool struct {
 	closed        atomic.Bool
 }
 
-func NewBucketingPool(ctx context.Context, wasmMain *WASMMain, sdkKey string, options *DVCOptions) (*BucketingPool, error) {
+func NewBucketingPool(ctx context.Context, wasmMain *WASMMain, sdkKey string, platformData *PlatformData, options *DVCOptions) (*BucketingPool, error) {
 	bucketingPool := &BucketingPool{
 		ctx: ctx,
 	}
@@ -31,7 +31,7 @@ func NewBucketingPool(ctx context.Context, wasmMain *WASMMain, sdkKey string, op
 	config.MinEvictableIdleTime = -1
 	config.TimeBetweenEvictionRuns = -1
 
-	bucketingPool.factory = MakeBucketingPoolFactory(wasmMain, sdkKey, options, bucketingPool)
+	bucketingPool.factory = MakeBucketingPoolFactory(wasmMain, sdkKey, platformData, options, bucketingPool)
 
 	bucketingPool.poolSwapMutex = sync.Mutex{}
 	bucketingPool.closed = atomic.Bool{}

--- a/bucketing_pool_factory.go
+++ b/bucketing_pool_factory.go
@@ -6,24 +6,26 @@ import (
 )
 
 type BucketingPoolFactory struct {
-	wasmMain *WASMMain
-	sdkKey   string
-	options  *DVCOptions
-	pool     *BucketingPool
+	wasmMain     *WASMMain
+	sdkKey       string
+	platformData *PlatformData
+	options      *DVCOptions
+	pool         *BucketingPool
 }
 
-func MakeBucketingPoolFactory(wasmMain *WASMMain, sdkKey string, options *DVCOptions, pool *BucketingPool) *BucketingPoolFactory {
+func MakeBucketingPoolFactory(wasmMain *WASMMain, sdkKey string, platformData *PlatformData, options *DVCOptions, pool *BucketingPool) *BucketingPoolFactory {
 	return &BucketingPoolFactory{
-		wasmMain: wasmMain,
-		sdkKey:   sdkKey,
-		options:  options,
-		pool:     pool,
+		wasmMain:     wasmMain,
+		sdkKey:       sdkKey,
+		platformData: platformData,
+		options:      options,
+		pool:         pool,
 	}
 }
 
 func (f *BucketingPoolFactory) MakeObject(ctx context.Context) (*pool.PooledObject, error) {
 	var bucketing = &BucketingPoolObject{}
-	err := bucketing.Initialize(f.wasmMain, f.sdkKey, f.options)
+	err := bucketing.Initialize(f.wasmMain, f.sdkKey, f.platformData, f.options)
 	if err != nil {
 		return nil, err
 	}

--- a/bucketing_pool_object.go
+++ b/bucketing_pool_object.go
@@ -17,9 +17,9 @@ type BucketingPoolObject struct {
 	clientCustomData *[]byte
 }
 
-func (o *BucketingPoolObject) Initialize(wasmMain *WASMMain, sdkKey string, options *DVCOptions) (err error) {
+func (o *BucketingPoolObject) Initialize(wasmMain *WASMMain, sdkKey string, platformData *PlatformData, options *DVCOptions) (err error) {
 	o.localBucketing = &WASMLocalBucketingClient{}
-	err = o.localBucketing.Initialize(wasmMain, sdkKey, options)
+	err = o.localBucketing.Initialize(wasmMain, sdkKey, platformData, options)
 
 	if err != nil {
 		return

--- a/client.go
+++ b/client.go
@@ -97,7 +97,7 @@ func NewDVCClient(sdkKey string, options *DVCOptions) (*DVCClient, error) {
 	if !c.DevCycleOptions.EnableCloudBucketing {
 		c.internalOnInitializedChannel = make(chan bool, 1)
 
-		err := c.setLBClient(sdkKey, c.platformData, options)
+		err := c.setLBClient(sdkKey, options)
 		if err != nil {
 			return c, err
 		}

--- a/client.go
+++ b/client.go
@@ -10,8 +10,10 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 
@@ -24,6 +26,17 @@ var (
 	jsonCheck = regexp.MustCompile("(?i:[application|text]/json)")
 	xmlCheck  = regexp.MustCompile("(?i:[application|text]/xml)")
 )
+
+func GeneratePlatformData() *api.PlatformData {
+	hostname, _ := os.Hostname()
+	return &PlatformData{
+		Platform:        "Go",
+		SdkType:         "server",
+		PlatformVersion: runtime.Version(),
+		Hostname:        hostname,
+		SdkVersion:      VERSION,
+	}
+}
 
 // DVCClient
 // In most cases there should be only one, shared, DVCClient.
@@ -88,7 +101,7 @@ func NewDVCClient(sdkKey string, options *DVCOptions) (*DVCClient, error) {
 	c.ctx = context.Background()
 	c.common.client = c
 	c.DevCycleOptions = options
-	c.platformData = (&PlatformData{}).Default(VERSION)
+	c.platformData = GeneratePlatformData()
 
 	if c.DevCycleOptions.Logger != nil {
 		SetLogger(c.DevCycleOptions.Logger)

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -12,9 +12,9 @@ import (
 
 const NATIVE_SDK = true
 
-func (c *DVCClient) setLBClient(sdkKey string, platformData *PlatformData, options *DVCOptions) error {
+func (c *DVCClient) setLBClient(sdkKey string, options *DVCOptions) error {
 	localBucketing := NewNativeLocalBucketing(sdkKey, options)
-	localBucketing.SetPlatformData(platformData)
+	localBucketing.SetPlatformData(c.platformData)
 	c.localBucketing = localBucketing
 
 	// Event queue stub that does nothing

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -87,9 +87,8 @@ func (n *NativeLocalBucketing) Variable(user DVCUser, variableKey string, variab
 	}, nil
 }
 
-func (N *NativeLocalBucketing) SetPlatformData(platformData *PlatformData) error {
+func (N *NativeLocalBucketing) SetPlatformData(platformData *PlatformData) {
 	native_bucketing.SetPlatformData(N.sdkKey, *platformData)
-	return nil
 }
 
 func (n *NativeLocalBucketing) Close() {

--- a/client_wasm_bucketing.go
+++ b/client_wasm_bucketing.go
@@ -4,11 +4,12 @@ package devcycle
 
 const NATIVE_SDK = false
 
-func (c *DVCClient) setLBClient(sdkKey string, options *DVCOptions) error {
-	localBucketing, err := NewWASMLocalBucketing(sdkKey, options)
+func (c *DVCClient) setLBClient(sdkKey string, platformData *PlatformData, options *DVCOptions) error {
+	localBucketing, err := NewWASMLocalBucketing(sdkKey, platformData, options)
 	if err != nil {
 		return err
 	}
+
 	c.localBucketing = localBucketing
 
 	eventQueue := &EventQueue{}

--- a/client_wasm_bucketing.go
+++ b/client_wasm_bucketing.go
@@ -4,8 +4,8 @@ package devcycle
 
 const NATIVE_SDK = false
 
-func (c *DVCClient) setLBClient(sdkKey string, platformData *PlatformData, options *DVCOptions) error {
-	localBucketing, err := NewWASMLocalBucketing(sdkKey, platformData, options)
+func (c *DVCClient) setLBClient(sdkKey string, options *DVCOptions) error {
+	localBucketing, err := NewWASMLocalBucketing(sdkKey, c.platformData, options)
 	if err != nil {
 		return err
 	}

--- a/localbucketing.go
+++ b/localbucketing.go
@@ -88,23 +88,6 @@ func (lb *WASMLocalBucketing) SetClientCustomData(customData map[string]interfac
 	return lb.bucketingObjectPool.SetClientCustomData(customDataJSON)
 }
 
-func (lb *WASMLocalBucketing) SetPlatformData(platformData *PlatformData) error {
-	// set internal version first
-	lb.localBucketingClient.platformData = platformData
-
-	platformDataJSON, err := json.Marshal(platformData)
-
-	if err != nil {
-		return err
-	}
-	// push the data into the WASM
-	err = lb.localBucketingClient.SetPlatformDataJSON(platformDataJSON)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 func (lb *WASMLocalBucketing) StoreConfig(config []byte, eTag string) error {
 	err := lb.localBucketingClient.StoreConfig(config)
 	if err != nil {

--- a/localbucketing_test.go
+++ b/localbucketing_test.go
@@ -19,7 +19,8 @@ func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
 	fatalErr(t, err)
 
 	localBucketing := WASMLocalBucketingClient{}
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -36,7 +37,8 @@ func BenchmarkDevCycleLocalBucketing_Initialize(b *testing.B) {
 			b.Fatal(err)
 		}
 		localBucketing := WASMLocalBucketingClient{}
-		err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+		platformData := (&PlatformData{}).Default(VERSION)
+		err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -51,7 +53,8 @@ func TestDevCycleLocalBucketing_GenerateBucketedConfigForUser(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +64,7 @@ func TestDevCycleLocalBucketing_GenerateBucketedConfigForUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = localBucketing.SetPlatformData([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
+	err = localBucketing.SetPlatformDataJSON([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +95,8 @@ func TestDevCycleLocalBucketing_StoreConfig(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 
 	if err != nil {
 		t.Fatal(err)
@@ -114,7 +118,8 @@ func BenchmarkDevCycleLocalBucketing_StoreConfig(b *testing.B) {
 		b.Fatal(err)
 	}
 	localBucketing := WASMLocalBucketingClient{}
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -139,12 +144,13 @@ func TestDevCycleLocalBucketing_SetPlatformData(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = localBucketing.SetPlatformData([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
+	err = localBucketing.SetPlatformDataJSON([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +168,8 @@ func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B)
 		b.Fatal(err)
 	}
 	localBucketing := WASMLocalBucketingClient{}
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -172,7 +179,7 @@ func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B)
 		b.Fatal(err)
 	}
 
-	err = localBucketing.SetPlatformData([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
+	err = localBucketing.SetPlatformDataJSON([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -203,7 +210,8 @@ func BenchmarkDevCycleLocalBucketing_VariableForUser_PB(b *testing.B) {
 	}
 	localBucketing := WASMLocalBucketingClient{}
 
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{
 		AdvancedOptions: AdvancedOptions{
 			MaxMemoryAllocationBuckets: 1,
 		},
@@ -218,7 +226,7 @@ func BenchmarkDevCycleLocalBucketing_VariableForUser_PB(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	err = localBucketing.SetPlatformData([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
+	err = localBucketing.SetPlatformDataJSON([]byte(`{"platform": "golang-testing", "sdkType": "server", "platformVersion": "testing", "deviceModel": "testing", "sdkVersion":"testing"}`))
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -268,7 +276,8 @@ func TestDevCycleLocalBucketing_newAssemblyScriptNoPoolByteArray(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, &DVCOptions{})
+	platformData := (&PlatformData{}).Default(VERSION)
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
 
 	if err != nil {
 		t.Fatal(err)

--- a/localbucketing_test.go
+++ b/localbucketing_test.go
@@ -19,8 +19,7 @@ func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
 	fatalErr(t, err)
 
 	localBucketing := WASMLocalBucketingClient{}
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,8 +36,7 @@ func BenchmarkDevCycleLocalBucketing_Initialize(b *testing.B) {
 			b.Fatal(err)
 		}
 		localBucketing := WASMLocalBucketingClient{}
-		platformData := (&PlatformData{}).Default(VERSION)
-		err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+		err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -53,8 +51,7 @@ func TestDevCycleLocalBucketing_GenerateBucketedConfigForUser(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,8 +92,7 @@ func TestDevCycleLocalBucketing_StoreConfig(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 
 	if err != nil {
 		t.Fatal(err)
@@ -118,8 +114,7 @@ func BenchmarkDevCycleLocalBucketing_StoreConfig(b *testing.B) {
 		b.Fatal(err)
 	}
 	localBucketing := WASMLocalBucketingClient{}
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -144,8 +139,7 @@ func TestDevCycleLocalBucketing_SetPlatformData(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,8 +162,7 @@ func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B)
 		b.Fatal(err)
 	}
 	localBucketing := WASMLocalBucketingClient{}
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -210,8 +203,7 @@ func BenchmarkDevCycleLocalBucketing_VariableForUser_PB(b *testing.B) {
 	}
 	localBucketing := WASMLocalBucketingClient{}
 
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{
 		AdvancedOptions: AdvancedOptions{
 			MaxMemoryAllocationBuckets: 1,
 		},
@@ -276,8 +268,7 @@ func TestDevCycleLocalBucketing_newAssemblyScriptNoPoolByteArray(t *testing.T) {
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
 	localBucketing := WASMLocalBucketingClient{}
-	platformData := (&PlatformData{}).Default(VERSION)
-	err = localBucketing.Initialize(&wasmMain, test_environmentKey, platformData, &DVCOptions{})
+	err = localBucketing.Initialize(&wasmMain, test_environmentKey, GeneratePlatformData(), &DVCOptions{})
 
 	if err != nil {
 		t.Fatal(err)

--- a/native_bucketing/bucketing_test.go
+++ b/native_bucketing/bucketing_test.go
@@ -394,11 +394,9 @@ func TestClientData(t *testing.T) {
 			"favouriteFood": "pizza",
 			"favouriteNull": nil,
 		},
-	}.GetPopulatedUser()
-
-	user.PlatformData = &PlatformData{
+	}.GetPopulatedUser(&PlatformData{
 		PlatformVersion: "1.1.2",
-	}
+	})
 
 	err := SetConfig(test_config, "test", "")
 	require.NoError(t, err)
@@ -431,10 +429,9 @@ func TestClientData(t *testing.T) {
 		CustomData: map[string]interface{}{
 			"favouriteFood": "NOT PIZZA!",
 		},
-	}.GetPopulatedUser()
-	user2.PlatformData = &PlatformData{
+	}.GetPopulatedUser(&PlatformData{
 		PlatformVersion: "1.1.2",
-	}
+	})
 	bucketedUserConfig, err = GenerateBucketedConfig("test", user2, nil)
 	require.NoError(t, err)
 
@@ -443,19 +440,15 @@ func TestClientData(t *testing.T) {
 }
 
 func TestVariableForUser(t *testing.T) {
-
-	user := DVCPopulatedUser{
-		DVCUser: DVCUser{
-			UserId: "CPopultest",
-			CustomData: map[string]interface{}{
-				"favouriteDrink": "coffee",
-				"favouriteFood":  "pizza",
-			},
+	user := DVCUser{
+		UserId: "CPopultest",
+		CustomData: map[string]interface{}{
+			"favouriteDrink": "coffee",
+			"favouriteFood":  "pizza",
 		},
-		PlatformData: &PlatformData{
-			PlatformVersion: "1.1.2",
-		},
-	}
+	}.GetPopulatedUser(&PlatformData{
+		PlatformVersion: "1.1.2",
+	})
 
 	err := SetConfig(test_config, "test", "")
 	require.NoError(t, err)

--- a/native_bucketing/datamanager_platform.go
+++ b/native_bucketing/datamanager_platform.go
@@ -1,22 +1,5 @@
 package native_bucketing
 
-import (
-	"fmt"
-)
-
-var platformDataMap = map[string]PlatformData{}
-
-func GetPlatformData(sdkKey string) (data *PlatformData, err error) {
-	if data, ok := platformDataMap[sdkKey]; ok {
-		return &data, nil
-	}
-	return nil, fmt.Errorf("no platform data found for sdkKey %s", sdkKey)
-}
-
-func SetPlatformData(sdkKey string, data PlatformData) {
-	platformDataMap[sdkKey] = data
-}
-
 var clientCustomData = map[string]map[string]interface{}{}
 
 func GetClientCustomData(sdkKey string) map[string]interface{} {

--- a/native_bucketing/datamanager_platform.go
+++ b/native_bucketing/datamanager_platform.go
@@ -6,11 +6,11 @@ import (
 
 var platformDataMap = map[string]PlatformData{}
 
-func GetPlatformData(token string) (data *PlatformData, err error) {
-	if data, ok := platformDataMap[token]; ok {
+func GetPlatformData(sdkKey string) (data *PlatformData, err error) {
+	if data, ok := platformDataMap[sdkKey]; ok {
 		return &data, nil
 	}
-	return nil, fmt.Errorf("no platform data found for token %s", token)
+	return nil, fmt.Errorf("no platform data found for sdkKey %s", sdkKey)
 }
 
 func SetPlatformData(sdkKey string, data PlatformData) {

--- a/version.go
+++ b/version.go
@@ -1,7 +1,3 @@
 package devcycle
 
-import (
-	"github.com/devcyclehq/go-server-sdk/v2/api"
-)
-
-const VERSION = api.VERSION
+const VERSION = "2.9.4"


### PR DESCRIPTION
Refactored how the platformData is set into the bucketing code so it is now pushed by the DVCClient explicitly.

- Now loads the data into the native bucketing properly
- Required adding it to the entire execution chain for the WASM object pool