### PR TITLE
Prevent errors from being surfaced to the client in variable calls

### DIFF
--- a/client.go
+++ b/client.go
@@ -305,13 +305,14 @@ func (c *DVCClient) Variable(userdata DVCUser, key string, defaultValue interfac
 			return variable, nil
 		}
 		bucketedVariable, err := c.localBucketing.Variable(userdata, key, variableType)
+
 		sameTypeAsDefault := compareTypes(bucketedVariable.Value, convertedDefaultValue)
 		if bucketedVariable.Value != nil && sameTypeAsDefault {
 			variable.Value = bucketedVariable.Value
 			variable.IsDefaulted = false
 		} else {
 			if !sameTypeAsDefault && bucketedVariable.Value != nil {
-				warnf("Type mismatch for variable %s. Expected type %s, got %s",
+				debugf("Type mismatch for variable %s. Expected type %s, got %s",
 					key,
 					reflect.TypeOf(defaultValue).String(),
 					reflect.TypeOf(bucketedVariable.Value).String(),

--- a/client.go
+++ b/client.go
@@ -312,7 +312,7 @@ func (c *DVCClient) Variable(userdata DVCUser, key string, defaultValue interfac
 			variable.IsDefaulted = false
 		} else {
 			if !sameTypeAsDefault && bucketedVariable.Value != nil {
-				debugf("Type mismatch for variable %s. Expected type %s, got %s",
+				warnf("Type mismatch for variable %s. Expected type %s, got %s",
 					key,
 					reflect.TypeOf(defaultValue).String(),
 					reflect.TypeOf(bucketedVariable.Value).String(),

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -4,8 +4,9 @@ package devcycle
 
 import (
 	"fmt"
-	"github.com/devcyclehq/go-server-sdk/v2/api"
 	"sync"
+
+	"github.com/devcyclehq/go-server-sdk/v2/api"
 
 	"github.com/devcyclehq/go-server-sdk/v2/native_bucketing"
 )
@@ -70,7 +71,8 @@ func (n *NativeLocalBucketing) Variable(user DVCUser, variableKey string, variab
 	populatedUser := user.GetPopulatedUser(n.platformData)
 	variable, err := native_bucketing.VariableForUser(n.sdkKey, populatedUser, variableKey, variableType, false, clientCustomData)
 	if err != nil {
-		return defaultVar, err
+		// TODO: Are there errors that can be returned here that should be surfaced to the client?
+		return defaultVar, nil
 	}
 
 	return Variable{

--- a/native_bucketing/bucketing.go
+++ b/native_bucketing/bucketing.go
@@ -234,10 +234,6 @@ func VariableForUser(sdkKey string, user DVCPopulatedUser, variableKey string, v
 		return nil, err
 	}
 
-	if result.Variable.Type_ != variableType {
-		return nil, fmt.Errorf("variable %s is of type %s, not %s", variableKey, result.Variable.Type_, variableType)
-	}
-
 	return &result.Variable, nil
 }
 


### PR DESCRIPTION
We don't expect variable calls to ever return errors, or log when something unexpected happens other than a type mismatch.

This error silencing is basically in line with what the Node SDK does, but at some point we might want to look through the errors and see if any of them represent conditions where we'd still want to log something.