### PR TITLE
DVC-7067 - optimized createPopulatedUser()

### DIFF
--- a/api/model_user_data.go
+++ b/api/model_user_data.go
@@ -54,6 +54,7 @@ func (user DVCUser) GetPopulatedUser(platformData *PlatformData) DVCPopulatedUse
 	}
 }
 
+// GetPopulatedUserWithTime returns a populated user with a specific created date
 func (user DVCUser) GetPopulatedUserWithTime(platformData *PlatformData, createDate time.Time) DVCPopulatedUser {
 	return DVCPopulatedUser{
 		user,

--- a/api/model_user_data.go
+++ b/api/model_user_data.go
@@ -54,6 +54,14 @@ func (user DVCUser) GetPopulatedUser(platformData *PlatformData) DVCPopulatedUse
 	}
 }
 
+func (user DVCUser) GetPopulatedUserWithTime(platformData *PlatformData, createDate time.Time) DVCPopulatedUser {
+	return DVCPopulatedUser{
+		user,
+		platformData,
+		createDate,
+	}
+}
+
 type UserFeatureData struct {
 	User        DVCUser `json:"user"`
 	FeatureVars map[string]string

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -5,6 +5,7 @@ package devcycle
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/devcyclehq/go-server-sdk/v2/api"
 
@@ -12,6 +13,8 @@ import (
 )
 
 const NATIVE_SDK = true
+
+var DEFAULT_USER_TIME = time.Time{}
 
 func (c *DVCClient) setLBClient(sdkKey string, options *DVCOptions) error {
 	localBucketing := NewNativeLocalBucketing(sdkKey, c.platformData, options)
@@ -47,7 +50,7 @@ func (n *NativeLocalBucketing) StoreConfig(configJSON []byte, eTag string) error
 }
 
 func (n *NativeLocalBucketing) GenerateBucketedConfigForUser(user DVCUser) (ret *BucketedUserConfig, err error) {
-	populatedUser := user.GetPopulatedUser(n.platformData)
+	populatedUser := user.GetPopulatedUserWithTime(n.platformData, DEFAULT_USER_TIME)
 	clientCustomData := native_bucketing.GetClientCustomData(n.sdkKey)
 	return native_bucketing.GenerateBucketedConfig(n.sdkKey, populatedUser, clientCustomData)
 }
@@ -68,7 +71,7 @@ func (n *NativeLocalBucketing) Variable(user DVCUser, variableKey string, variab
 		IsDefaulted:  true,
 	}
 	clientCustomData := native_bucketing.GetClientCustomData(n.sdkKey)
-	populatedUser := user.GetPopulatedUser(n.platformData)
+	populatedUser := user.GetPopulatedUserWithTime(n.platformData, DEFAULT_USER_TIME)
 	variable, err := native_bucketing.VariableForUser(n.sdkKey, populatedUser, variableKey, variableType, false, clientCustomData)
 	if err != nil {
 		// TODO: Are there errors that can be returned here that should be surfaced to the client?

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -14,6 +14,7 @@ import (
 
 const NATIVE_SDK = true
 
+// This value will always be set to zero as the user.CreatedDate is not actually used in native bucketing
 var DEFAULT_USER_TIME = time.Time{}
 
 func (c *DVCClient) setLBClient(sdkKey string, options *DVCOptions) error {


### PR DESCRIPTION
Setup native SDK to not call time.now() when it calls  createPopulatedUser() as native bucketing never users the createdDate value