### PR TITLE
Optimization in bucketing and segmentation

### DIFF
--- a/native_bucketing/model_config_body.go
+++ b/native_bucketing/model_config_body.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 )
 
 type Variable struct {
@@ -46,7 +47,7 @@ func (c *configBody) GetFeatureForVariableId(id string) *ConfigFeature {
 }
 
 func (c *configBody) compile(etag string) {
-
+	// Build mappings of IDs and keys to features and variables.
 	variableIdToFeatureMap := make(map[string]ConfigFeature)
 	for _, feature := range c.Features {
 		for _, v := range feature.Variations {
@@ -69,6 +70,15 @@ func (c *configBody) compile(etag string) {
 	c.variableIdMap = variableIdMap
 	c.variableKeyMap = variableKeyMap
 	c.etag = etag
+
+	// Sort the feature distributions by "_variation" attribute in descending alphabetical order
+	for _, feature := range c.Features {
+		for _, target := range feature.Configuration.Targets {
+			sort.Slice(target.Distribution, func(i, j int) bool {
+				return target.Distribution[i].Variation > target.Distribution[j].Variation
+			})
+		}
+	}
 }
 
 func (c *configBody) FindVariable(key string) (Variable, error) {

--- a/native_bucketing/model_filters.go
+++ b/native_bucketing/model_filters.go
@@ -210,30 +210,6 @@ func (u *UserFilter) compileValues() error {
 	return nil
 }
 
-func (u UserFilter) GetStringValues() []string {
-	if u.CompiledStringVals != nil {
-		return u.CompiledStringVals
-	} else {
-		return []string{}
-	}
-}
-
-func (u UserFilter) GetBooleanValues() []bool {
-	if u.CompiledBoolVals != nil {
-		return u.CompiledBoolVals
-	} else {
-		return []bool{}
-	}
-}
-
-func (u UserFilter) GetNumberValues() []float64 {
-	if u.CompiledNumVals != nil {
-		return u.CompiledNumVals
-	} else {
-		return []float64{}
-	}
-}
-
 type CustomDataFilter struct {
 	*UserFilter
 	DataKey     string `json:"dataKey"`
@@ -303,7 +279,7 @@ func checkNumbersFilterJSONValue(jsonValue interface{}, filter *UserFilter) bool
 
 func _checkNumbersFilter(number float64, filter *UserFilter) bool {
 	operator := filter.GetComparator()
-	values := getFilterValuesAsF64(filter)
+	values := filter.CompiledNumVals
 	return _checkNumberFilter(number, values, operator)
 }
 
@@ -317,7 +293,7 @@ func checkStringsFilter(str string, filter *UserFilter) bool {
 		return false
 	}
 	operator := filter.GetComparator()
-	values := getFilterValuesAsString(filter)
+	values := filter.CompiledStringVals
 	if operator == "=" {
 		return str != "" && contains(values, str)
 	} else if operator == "!=" {
@@ -347,7 +323,7 @@ func _checkBooleanFilter(b bool, filter *UserFilter) bool {
 		return false
 	}
 	operator := filter.GetComparator()
-	values := getFilterValuesAsBoolean(filter)
+	values := filter.CompiledBoolVals
 
 	if operator == "contain" || operator == "=" {
 		return contains(values, b)
@@ -364,7 +340,7 @@ func _checkBooleanFilter(b bool, filter *UserFilter) bool {
 
 func checkVersionFilters(appVersion string, filter *UserFilter) bool {
 	operator := filter.GetComparator()
-	values := getFilterValuesAsString(filter)
+	values := filter.CompiledStringVals
 	// dont need to do semver if they"re looking for an exact match. Adds support for non semver versions.
 	if operator == "=" {
 		return checkStringsFilter(appVersion, filter)
@@ -379,52 +355,6 @@ func getFilterValues(filter *UserFilter) []interface{} {
 	for _, value := range values {
 		if value != nil {
 			ret = append(ret, value)
-		}
-	}
-	return ret
-}
-
-func getFilterValuesAsString(filter *UserFilter) []string {
-	// TODO: Just use compiled values here?
-	var ret []string
-	jsonValues := getFilterValues(filter)
-	for _, jsonValue := range jsonValues {
-		switch v := jsonValue.(type) {
-		case string:
-			ret = append(ret, v)
-		default:
-			continue
-		}
-	}
-	return ret
-}
-
-func getFilterValuesAsF64(filter *UserFilter) []float64 {
-	// TODO: Just use compiled values here?
-	var ret []float64
-	jsonValues := getFilterValues(filter)
-	for _, jsonValue := range jsonValues {
-		switch v := jsonValue.(type) {
-		case int:
-		case float64:
-			ret = append(ret, v)
-		default:
-			continue
-		}
-	}
-	return ret
-}
-
-func getFilterValuesAsBoolean(filter *UserFilter) []bool {
-	// TODO: Just use compiled values here?
-	var ret []bool
-	jsonValues := getFilterValues(filter)
-	for _, jsonValue := range jsonValues {
-		switch v := jsonValue.(type) {
-		case bool:
-			ret = append(ret, v)
-		default:
-			continue
 		}
 	}
 	return ret

--- a/native_bucketing/model_target.go
+++ b/native_bucketing/model_target.go
@@ -2,7 +2,6 @@ package native_bucketing
 
 import (
 	"fmt"
-	"sort"
 	"time"
 )
 
@@ -16,12 +15,6 @@ type Target struct {
 func (t *Target) DecideTargetVariation(boundedHash float64) (string, error) {
 	var distributionIndex float64 = 0
 	var previousDistributionIndex float64 = 0
-
-	// Sort the distributions by _variation in descending alphabetical order
-	// TODO: Can we pre-sort when the config is parsed?
-	sort.Slice(t.Distribution, func(i, j int) bool {
-		return t.Distribution[i].Variation > t.Distribution[j].Variation
-	})
 
 	for _, d := range t.Distribution {
 		distributionIndex += d.Percentage


### PR DESCRIPTION
- Moved sorting of the distributions to config parsing
- Fixed some filtering code that didn't use the precompiled slices of values and resulted in a lot of allocations

```
BenchmarkDVCClient_VariableSerial-12    	19352398	       614.4 ns/op	     384 B/op	       2 allocs/op
```