### PR TITLE
Fix contains vs equals in string filters

### DIFF
--- a/native_bucketing/bucketing.go
+++ b/native_bucketing/bucketing.go
@@ -102,7 +102,7 @@ type segmentedFeatureData struct {
 func evaluateSegmentationForFeature(config *configBody, feature ConfigFeature, user DVCPopulatedUser, clientCustomData map[string]interface{}) *Target {
 	for _, target := range feature.Configuration.Targets {
 		if _evaluateOperator(target.Audience.Filters, config.Audiences, user, clientCustomData) {
-			return &target
+			return target
 		}
 	}
 	return nil

--- a/native_bucketing/model_feature_configuration.go
+++ b/native_bucketing/model_feature_configuration.go
@@ -5,7 +5,7 @@ type FeatureConfiguration struct {
 	Prerequisites    []FeaturePrerequisites `json:"prerequisites"`
 	WinningVariation FeatureVariation       `json:"winningVariation"`
 	ForcedUsers      map[string]string      `json:"forcedUsers"`
-	Targets          []Target               `json:"targets"`
+	Targets          []*Target              `json:"targets"`
 }
 
 type FeaturePrerequisites struct {

--- a/native_bucketing/model_filters.go
+++ b/native_bucketing/model_filters.go
@@ -284,33 +284,41 @@ func _checkNumbersFilter(number float64, filter *UserFilter) bool {
 }
 
 func checkStringsFilter(str string, filter *UserFilter) bool {
-	contains := func(arr []string, substr string) bool {
-		for _, s := range arr {
-			if strings.Contains(s, substr) {
-				return true
-			}
-		}
-		return false
-	}
 	operator := filter.GetComparator()
 	values := filter.CompiledStringVals
 	if operator == "=" {
-		return str != "" && contains(values, str)
+		return str != "" && stringArrayIn(values, str)
 	} else if operator == "!=" {
-		return str != "" && !contains(values, str)
+		return str != "" && !stringArrayIn(values, str)
 	} else if operator == "exist" {
 		return str != ""
 	} else if operator == "!exist" {
 		return str == ""
 	} else if operator == "contain" {
-		// TODO: This is not the same as the old behaviour.
-		return str != "" && contains(values, str)
+		return str != "" && stringArrayContains(values, str)
 	} else if operator == "!contain" {
-		// TODO: This is not the same as the old behaviour.
-		return str == "" || !contains(values, str)
+		return str == "" || !stringArrayContains(values, str)
 	} else {
 		return false
 	}
+}
+
+func stringArrayIn(arr []string, search string) bool {
+	for _, s := range arr {
+		if s == search {
+			return true
+		}
+	}
+	return false
+}
+
+func stringArrayContains(substrings []string, search string) bool {
+	for _, substring := range substrings {
+		if strings.Contains(search, substring) {
+			return true
+		}
+	}
+	return false
 }
 
 func _checkBooleanFilter(b bool, filter *UserFilter) bool {
@@ -347,15 +355,4 @@ func checkVersionFilters(appVersion string, filter *UserFilter) bool {
 	} else {
 		return checkVersionFilter(appVersion, values, operator)
 	}
-}
-
-func getFilterValues(filter *UserFilter) []interface{} {
-	values := filter.Values
-	var ret []interface{}
-	for _, value := range values {
-		if value != nil {
-			ret = append(ret, value)
-		}
-	}
-	return ret
 }

--- a/native_bucketing/model_filters_test.go
+++ b/native_bucketing/model_filters_test.go
@@ -1,0 +1,46 @@
+package native_bucketing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckStringsFilter(t *testing.T) {
+	tests := []struct {
+		name       string
+		comparator string
+		values     []string
+		subject    string
+		expected   bool
+	}{
+		{"=_empty", ComparatorEqual, []string{""}, "", false},
+		{"=_match", ComparatorEqual, []string{"foo"}, "foo", true},
+		{"=_nomatch", ComparatorEqual, []string{"foo"}, "fo", false},
+		{"!=_empty", ComparatorNotEqual, []string{""}, "", false},
+		{"!=_match", ComparatorNotEqual, []string{"foo"}, "foo", false},
+		{"!=_nomatch", ComparatorNotEqual, []string{"foo"}, "bar", true},
+		{"exist_empty", ComparatorExist, []string{}, "", false},
+		{"exist_notempty", ComparatorExist, []string{}, "exists", true},
+		{"exist_empty", ComparatorNotExist, []string{}, "", true},
+		{"exist_notempty", ComparatorNotExist, []string{}, "exists", false},
+		{"contain_empty", ComparatorContain, []string{""}, "", false},
+		{"contain_match", ComparatorContain, []string{"oob"}, "foobar", true},
+		{"contain_nomatch", ComparatorContain, []string{"foo"}, "bar", false},
+		{"contain_empty", ComparatorNotContain, []string{""}, "", true},
+		{"contain_match", ComparatorNotContain, []string{"oob"}, "foobar", false},
+		{"contain_nomatch", ComparatorNotContain, []string{"foo"}, "bar", true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			filter := &UserFilter{
+				filter: filter{
+					Comparator: test.comparator,
+				},
+				CompiledStringVals: test.values,
+			}
+			actual := checkStringsFilter(test.subject, filter)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
The implementation here was mixing up string contains vs. equals, which also slowed things down in the latter case.