### PR TITLE
remove use of util.Errorf for returning errors

### DIFF
--- a/bucketing_pool.go
+++ b/bucketing_pool.go
@@ -4,9 +4,11 @@ package devcycle
 
 import (
 	"context"
-	"github.com/devcyclehq/go-server-sdk/v2/util"
+	"fmt"
 	"sync"
 	"sync/atomic"
+
+	"github.com/devcyclehq/go-server-sdk/v2/util"
 
 	"github.com/devcyclehq/go-server-sdk/v2/proto"
 	pool "github.com/jolestar/go-commons-pool/v2"
@@ -59,7 +61,7 @@ func NewBucketingPool(ctx context.Context, wasmMain *WASMMain, sdkKey string, pl
 
 func (p *BucketingPool) VariableForUser(paramsBuffer []byte) (*proto.SDKVariable_PB, error) {
 	if p.closed.Load() {
-		return nil, util.Errorf("Cannot evaluate variable on closed pool")
+		return nil, fmt.Errorf("Cannot evaluate variable on closed pool")
 	}
 	currentPool := p.currentPool.Load()
 	bucketing, err := currentPool.BorrowObject(p.ctx)
@@ -88,7 +90,7 @@ func (p *BucketingPool) ProcessAll(
 	process func(object *BucketingPoolObject) error,
 ) (err error) {
 	if p.closed.Load() {
-		return util.Errorf("Cannot process task on closed pool")
+		return fmt.Errorf("Cannot process task on closed pool")
 	}
 	p.poolSwapMutex.Lock()
 	defer p.poolSwapMutex.Unlock()
@@ -143,7 +145,7 @@ func (p *BucketingPool) ProcessAll(
 
 func (p *BucketingPool) StoreConfig(config []byte) error {
 	if p.closed.Load() {
-		return util.Errorf("Cannot set config on closed pool")
+		return fmt.Errorf("Cannot set config on closed pool")
 	}
 	util.Debugf("Setting config on all workers")
 	return p.ProcessAll("StoreConfig", func(object *BucketingPoolObject) error {
@@ -153,7 +155,7 @@ func (p *BucketingPool) StoreConfig(config []byte) error {
 
 func (p *BucketingPool) SetClientCustomData(customData []byte) error {
 	if p.closed.Load() {
-		return util.Errorf("Cannot set client custom data on closed pool")
+		return fmt.Errorf("Cannot set client custom data on closed pool")
 	}
 	util.Debugf("Setting client custom data on all workers")
 	return p.ProcessAll("SetClientCustomData", func(object *BucketingPoolObject) error {

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -101,7 +101,7 @@ func (n *NativeLocalBucketing) Variable(user User, variableKey string, variableT
 func (n *NativeLocalBucketing) Close() {
 	err := n.eventQueue.Close()
 	if err != nil {
-		_ = util.Errorf("Error closing event queue: %v", err)
+		util.Errorf("Error closing event queue: %v", err)
 	}
 }
 

--- a/configmanager.go
+++ b/configmanager.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/devcyclehq/go-server-sdk/v2/util"
 	"io"
 	"net/http"
 	"sync/atomic"
 	"time"
+
+	"github.com/devcyclehq/go-server-sdk/v2/util"
 )
 
 const CONFIG_RETRIES = 1
@@ -80,7 +81,7 @@ func (e *EnvironmentConfigManager) fetchConfig(numRetriesRemaining int) (err err
 	defer func() {
 		if r := recover(); r != nil {
 			// get the stack trace and potentially log it here
-			err = util.Errorf("recovered from panic in fetchConfig: %v", r)
+			err = fmt.Errorf("recovered from panic in fetchConfig: %v", r)
 		}
 	}()
 
@@ -111,12 +112,12 @@ func (e *EnvironmentConfigManager) fetchConfig(numRetriesRemaining int) (err err
 		return nil
 	case statusCode == http.StatusForbidden:
 		e.stopPolling()
-		return util.Errorf("invalid SDK key. Aborting config polling")
+		return fmt.Errorf("invalid SDK key. Aborting config polling")
 	case statusCode >= 500:
 		// Retryable Errors. Continue polling.
 		util.Warnf("Config fetch failed. Status:" + resp.Status)
 	default:
-		err = util.Errorf("Unexpected response code: %d\n"+
+		err = fmt.Errorf("Unexpected response code: %d\n"+
 			"Body: %s\n"+
 			"URL: %s\n"+
 			"Headers: %s\n"+
@@ -140,7 +141,7 @@ func (e *EnvironmentConfigManager) setConfigFromResponse(response *http.Response
 	// Check
 	valid := json.Valid(config)
 	if !valid {
-		return util.Errorf("invalid JSON data received for config")
+		return fmt.Errorf("invalid JSON data received for config")
 	}
 
 	e.configETag = response.Header.Get("Etag")

--- a/event_manager.go
+++ b/event_manager.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"sync"
@@ -88,11 +89,11 @@ func NewEventManager(options *Options, localBucketing InternalEventQueue, cfg *H
 
 func (e *EventManager) QueueEvent(user User, event Event) error {
 	if e.closed {
-		return util.Errorf("DevCycle client was closed, no more events can be tracked.")
+		return fmt.Errorf("DevCycle client was closed, no more events can be tracked.")
 	}
 	queueSize, err := e.internalQueue.UserQueueLength()
 	if err != nil {
-		return util.Errorf("Failed to check queue size, dropping event: %w", err)
+		return fmt.Errorf("Failed to check queue size, dropping event: %w", err)
 	}
 
 	if queueSize >= e.options.FlushEventQueueSize {
@@ -104,7 +105,7 @@ func (e *EventManager) QueueEvent(user User, event Event) error {
 	}
 	err = e.internalQueue.QueueEvent(user, event)
 	if err != nil && errors.Is(err, ErrQueueFull) {
-		return util.Errorf("event queue is full, dropping event: %+v", event)
+		return fmt.Errorf("event queue is full, dropping event: %+v", event)
 	}
 	return err
 }
@@ -125,7 +126,7 @@ func (e *EventManager) FlushEvents() (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			// get the stack trace and potentially log it here
-			err = util.Errorf("recovered from panic in FlushEvents: %v", r)
+			err = fmt.Errorf("recovered from panic in FlushEvents: %v", r)
 		}
 	}()
 
@@ -153,13 +154,13 @@ func (e *EventManager) flushEventPayload(
 	var resp *http.Response
 	requestBody, err := json.Marshal(BatchEventsBody{Batch: payload.Records})
 	if err != nil {
-		_ = util.Errorf("Failed to marshal batch events body: %s", err)
+		util.Errorf("Failed to marshal batch events body: %s", err)
 		e.reportPayloadFailure(payload, false, failures, retryableFailures)
 		return
 	}
 	req, err = http.NewRequest("POST", eventsHost+"/v1/events/batch", bytes.NewReader(requestBody))
 	if err != nil {
-		_ = util.Errorf("Failed to create request to events api: %s", err)
+		util.Errorf("Failed to create request to events api: %s", err)
 		e.reportPayloadFailure(payload, false, failures, retryableFailures)
 		return
 	}
@@ -171,7 +172,7 @@ func (e *EventManager) flushEventPayload(
 	resp, err = e.cfg.HTTPClient.Do(req)
 
 	if err != nil {
-		_ = util.Errorf("Failed to make request to events api: %s", err)
+		util.Errorf("Failed to make request to events api: %s", err)
 		e.reportPayloadFailure(payload, false, failures, retryableFailures)
 		return
 	}
@@ -188,7 +189,7 @@ func (e *EventManager) flushEventPayload(
 	// "keep-alive" request.
 	responseBody, readError := io.ReadAll(resp.Body)
 	if readError != nil {
-		_ = util.Errorf("Failed to read response body: %v", readError)
+		util.Errorf("Failed to read response body: %v", readError)
 		e.reportPayloadFailure(payload, false, failures, retryableFailures)
 		return
 	}
@@ -201,7 +202,7 @@ func (e *EventManager) flushEventPayload(
 
 	if resp.StatusCode >= 400 {
 		e.reportPayloadFailure(payload, false, failures, retryableFailures)
-		_ = util.Errorf("Error sending events - Response: %s", string(responseBody))
+		util.Errorf("Error sending events - Response: %s", string(responseBody))
 		return
 	}
 
@@ -210,7 +211,7 @@ func (e *EventManager) flushEventPayload(
 		return
 	}
 
-	_ = util.Errorf("unknown status code when flushing events %d", resp.StatusCode)
+	util.Errorf("unknown status code when flushing events %d", resp.StatusCode)
 	e.reportPayloadFailure(payload, false, failures, retryableFailures)
 }
 

--- a/native_bucketing/event_queue.go
+++ b/native_bucketing/event_queue.go
@@ -283,21 +283,21 @@ func (eq *EventQueue) HandleFlushResults(successPayloads []string, failurePayloa
 
 	for _, payloadId := range successPayloads {
 		if err := eq.reportPayloadSuccess(payloadId); err != nil {
-			_ = util.Errorf("failed to mark event payloads as successful", err)
+			util.Errorf("failed to mark event payloads as successful: %v", err)
 		} else {
 			reported++
 		}
 	}
 	for _, payloadId := range failurePayloads {
 		if err := eq.reportPayloadFailure(payloadId, false); err != nil {
-			_ = util.Errorf("failed to mark event payloads as failed", err)
+			util.Errorf("failed to mark event payloads as failed: %v", err)
 		} else {
 			reported++
 		}
 	}
 	for _, payloadId := range failureWithRetryPayloads {
 		if err := eq.reportPayloadFailure(payloadId, true); err != nil {
-			_ = util.Errorf("failed to mark event payloads as failed", err)
+			util.Errorf("failed to mark event payloads as failed: %v", err)
 		} else {
 			reported++
 		}
@@ -333,7 +333,7 @@ func (eq *EventQueue) reportPayloadSuccess(payloadId string) error {
 	if _, ok := eq.pendingPayloads[payloadId]; ok {
 		delete(eq.pendingPayloads, payloadId)
 	} else {
-		return util.Errorf("Failed to find payload: %s to mark as success", payloadId)
+		return fmt.Errorf("Failed to find payload: %s to mark as success", payloadId)
 	}
 	return nil
 }
@@ -346,7 +346,7 @@ func (eq *EventQueue) reportPayloadFailure(payloadId string, retryable bool) err
 			delete(eq.pendingPayloads, payloadId)
 		}
 	} else {
-		return util.Errorf("Failed to find payload: %s, retryable: %b", payloadId, retryable)
+		return fmt.Errorf("Failed to find payload: %s, retryable: %v", payloadId, retryable)
 	}
 	return nil
 }

--- a/request.go
+++ b/request.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"encoding/xml"
-	"github.com/devcyclehq/go-server-sdk/v2/util"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -53,7 +53,7 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 	}
 
 	if bodyBuf.Len() == 0 {
-		err = util.Errorf("Invalid body type %s\n", contentType)
+		err = fmt.Errorf("Invalid body type %s\n", contentType)
 		return nil, err
 	}
 	return bodyBuf, nil

--- a/util/logger_debug.go
+++ b/util/logger_debug.go
@@ -26,6 +26,6 @@ func Warnf(format string, a ...any) {
 	globalLogger.Warnf(format, a...)
 }
 
-func Errorf(format string, a ...any) error {
-	return globalLogger.Errorf(format, a...)
+func Errorf(format string, a ...any) {
+	globalLogger.Errorf(format, a...)
 }

--- a/util/logger_disabled.go
+++ b/util/logger_disabled.go
@@ -10,13 +10,4 @@ func Debugf(format string, a ...any) {}
 
 func Warnf(format string, a ...any) {}
 
-// TODO: Remove this placeholder error once all calls to Errorf are removed from the hot paths
-func Errorf(format string, a ...any) error { return placeholderErrorInstance }
-
-type placeholderError struct{}
-
-func (placeholderError) Error() string {
-	return "Error in DevCycle SDK"
-}
-
-var placeholderErrorInstance = placeholderError{}
+func Errorf(format string, a ...any) {}


### PR DESCRIPTION
Turning off the logs by default in #190 meant that some formatted errors would have lost their messages. I replaced the combination log + return error helper `util.Errorf` with just an error log, and created errors separately here. It was a lot of not very important changes, so I broke it out into a separate PR.