### PR TITLE
DVC 7411: Fix race conditions and turn on race detector

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         go-version: 1.19
 
     - name: Test
-      run: make test
+      run: RACE=1 make test
 
     - name: Test Native Bucketing build
-      run: CGO_ENABLED=0 TAGS=native_bucketing make test
+      run: RACE=1 CGO_ENABLED=0 TAGS=native_bucketing make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,7 @@ jobs:
       run: RACE=1 make test
 
     - name: Test Native Bucketing build
-      run: RACE=1 CGO_ENABLED=0 TAGS=native_bucketing make test
+      run: RACE=1 TAGS=native_bucketing make test
+
+    - name: Test that CGO is not required for native bucketing
+      run: CGO_ENABLED=0 go test -tags native_bucketing -run="^$" ./...

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ To find usage documentation, visit our [docs](https://docs.devcycle.com/docs/sdk
 
 This SDK is supported by our [test harness](https://github.com/DevCycleHQ/test-harness), a test suite shared between all DevCycle SDKs for consistency.
 
+Unit tests can be run with the standard Go testing tools, or with `make test`. They are run automatically on PRs with the [Go race detector](https://go.dev/doc/articles/race_detector) enabled. To reproduce this locally, run with `RACE=1 make test` or `RACE=1 TAGS=native_bucketing make test`. Some race detector errors might only show up on Github actions due to differences in how quickly tests are executed.
+
 ## Configuration
 
 Configuration of the SDK is done through the `Options` struct.

--- a/event_manager_test.go
+++ b/event_manager_test.go
@@ -17,6 +17,7 @@ func TestEventManager_QueueEvent(t *testing.T) {
 
 	c, err := NewClient("dvc_server_token_hash", &Options{})
 	fatalErr(t, err)
+	defer c.Close()
 
 	_, err = c.Track(User{UserId: "j_test", DeviceModel: "testing"},
 		Event{Target: "customevent", Type_: "event"})
@@ -32,6 +33,7 @@ func TestEventManager_QueueEvent_100_DropEvent(t *testing.T) {
 
 	c, err := NewClient("dvc_server_token_hash", &Options{MaxEventQueueSize: 100, FlushEventQueueSize: 10})
 	fatalErr(t, err)
+	defer c.Close()
 
 	errored := false
 	for i := 0; i < 1000; i++ {
@@ -61,6 +63,7 @@ func TestEventManager_QueueEvent_100_Flush(t *testing.T) {
 		EventFlushIntervalMS:    time.Second,
 	})
 	fatalErr(t, err)
+	defer c.Close()
 
 	// Track up to FlushEventQueueSize events
 	for i := 0; i < 10; i++ {

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/jarcoal/httpmock v1.2.0
 	github.com/jolestar/go-commons-pool/v2 v2.1.2
 	github.com/matryer/try v0.0.0-20161228173917-9ac251b645a2
-	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.8.2
+	github.com/twmb/murmur3 v1.1.7
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
 	google.golang.org/protobuf v1.29.1
 )

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/maxatome/go-testdeep v1.11.0 h1:Tgh5efyCYyJFGUYiT0qxBSIDeXw0F5zSoatlo
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rwtodd/Go.Sed v0.0.0-20210816025313-55464686f9ef/go.mod h1:8AEUvGVi2uQ5b24BIhcr0GCcpd/RNAFWaN2CJFrWIIQ=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
-github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -45,6 +43,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/twmb/murmur3 v1.1.7 h1:ULWBiM04n/XoN3YMSJ6Z2pHDFLf+MeIVQU71ZPrvbWg=
+github.com/twmb/murmur3 v1.1.7/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/exp v0.0.0-20230321023759-10a507213a29 h1:ooxPy7fPvB4kwsA2h+iBNHkAbp/4JxTSwCmvdjEYmug=

--- a/native_bucketing/bucketing.go
+++ b/native_bucketing/bucketing.go
@@ -26,7 +26,7 @@ type boundedHash struct {
 }
 
 func generateBoundedHashes(userId, targetId string) boundedHash {
-	var targetHash = murmurhashV3([]byte(targetId), baseSeed)
+	var targetHash = murmurhashV3(targetId, baseSeed)
 	var bhash = boundedHash{
 		RolloutHash:   generateBoundedHash(userId+"_rollout", targetHash),
 		BucketingHash: generateBoundedHash(userId, targetHash),
@@ -35,7 +35,7 @@ func generateBoundedHashes(userId, targetId string) boundedHash {
 }
 
 func generateBoundedHash(input string, hashSeed uint32) float64 {
-	mh := murmurhashV3([]byte(input), hashSeed)
+	mh := murmurhashV3(input, hashSeed)
 	return float64(mh) / float64(maxHashValue)
 }
 

--- a/native_bucketing/event_queue.go
+++ b/native_bucketing/event_queue.go
@@ -139,7 +139,9 @@ func NewEventQueue(sdkKey string, options *api.EventQueueOptions) (*EventQueue, 
 		done:              cancel,
 	}
 
-	go eq.processEvents(ctx)
+	if !options.DisableAutomaticEventLogging || !options.DisableCustomEventLogging {
+		go eq.processEvents(ctx)
+	}
 
 	return eq, nil
 }
@@ -313,6 +315,12 @@ func (eq *EventQueue) Metrics() (int32, int32, int32) {
 func (eq *EventQueue) Close() (err error) {
 	eq.done()
 	return
+}
+
+func (eq *EventQueue) aggQueueLength() int {
+	eq.stateMutex.RLock()
+	defer eq.stateMutex.RUnlock()
+	return len(eq.aggEventQueue)
 }
 
 func (eq *EventQueue) UserQueueLength() int {

--- a/native_bucketing/murmurhash.go
+++ b/native_bucketing/murmurhash.go
@@ -1,8 +1,7 @@
 package native_bucketing
 
-import "github.com/spaolacci/murmur3"
+import "github.com/twmb/murmur3"
 
-func murmurhashV3(data []byte, seed uint32) uint32 {
-	mh := murmur3.Sum32WithSeed(data, seed)
-	return mh
+func murmurhashV3(data string, seed uint32) uint32 {
+	return murmur3.SeedStringSum32(seed, data)
 }

--- a/native_bucketing/murmurhash_test.go
+++ b/native_bucketing/murmurhash_test.go
@@ -1,0 +1,14 @@
+package native_bucketing
+
+// test for murmurhashv3
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMurmurhashV3(t *testing.T) {
+	input := "test"
+	hash := murmurhashV3(input, baseSeed)
+	require.Equal(t, uint32(0x99c02ae2), hash)
+}

--- a/wasm_bucketing_test.go
+++ b/wasm_bucketing_test.go
@@ -8,14 +8,9 @@ import (
 	"testing"
 
 	"github.com/devcyclehq/go-server-sdk/v2/proto"
-	"github.com/jarcoal/httpmock"
 )
 
 func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
-
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
@@ -28,9 +23,6 @@ func TestDevCycleLocalBucketing_Initialize(t *testing.T) {
 }
 
 func BenchmarkDevCycleLocalBucketing_Initialize(b *testing.B) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
 	for i := 0; i < b.N; i++ {
 		wasmMain := WASMMain{}
 		err := wasmMain.Initialize(nil)
@@ -46,9 +38,6 @@ func BenchmarkDevCycleLocalBucketing_Initialize(b *testing.B) {
 }
 
 func TestDevCycleLocalBucketing_GenerateBucketedConfigForUser(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
@@ -83,13 +72,9 @@ func TestDevCycleLocalBucketing_GenerateBucketedConfigForUser(t *testing.T) {
 	} else {
 		t.Fatal("Incorrectly bucketed user.")
 	}
-
 }
 
 func TestDevCycleLocalBucketing_StoreConfig(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
@@ -107,9 +92,6 @@ func TestDevCycleLocalBucketing_StoreConfig(t *testing.T) {
 }
 
 func BenchmarkDevCycleLocalBucketing_StoreConfig(b *testing.B) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(&Options{})
 	if err != nil {
@@ -133,10 +115,6 @@ func BenchmarkDevCycleLocalBucketing_StoreConfig(b *testing.B) {
 }
 
 func TestDevCycleLocalBucketing_SetPlatformData(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
-
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)
@@ -153,11 +131,6 @@ func TestDevCycleLocalBucketing_SetPlatformData(t *testing.T) {
 }
 
 func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B) {
-
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
-
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 	if err != nil {
@@ -193,11 +166,6 @@ func BenchmarkDevCycleLocalBucketing_GenerateBucketedConfigForUser(b *testing.B)
 }
 
 func BenchmarkDevCycleLocalBucketing_VariableForUser_PB(b *testing.B) {
-
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
-
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 	if err != nil {
@@ -263,9 +231,6 @@ func BenchmarkDevCycleLocalBucketing_VariableForUser_PB(b *testing.B) {
 }
 
 func TestDevCycleLocalBucketing_newAssemblyScriptNoPoolByteArray(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
 	wasmMain := WASMMain{}
 	err := wasmMain.Initialize(nil)
 	fatalErr(t, err)


### PR DESCRIPTION
Turning on the race detector in the unit tests turned up a couple of issues. The event queue ones were just caused by sketchy workarounds in the tests, but the library we were using for murmurhash was also causing an error.

Context on the cause is in this Github issue:
https://github.com/spaolacci/murmur3/issues/34

I switched to using twmb/murmur3, which doesn't trigger the race detector, appears to produce the same output, and is slightly faster.