### PR TITLE
DVC-7444: Release workflow for updating version.go

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [released]
+    types: [released, prereleased]
       
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  release:
+    types: [published] # TODO: change to released once this workflow is tested
+      
+permissions:
+  contents: write
+
+jobs:
+  update_version:
+    name: Update VERSION in Go code
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Get Release Version
+      run: |
+        echo "TAG_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+    - name: Ensure release tag looks like a valid version
+      run: echo "${TAG_VERSION}" | egrep '^v[0-9]+\.[0-9]+\.[0-9]+'
+
+    - uses: actions/checkout@v3
+
+    - name: Update appVersion in chart
+      run: |
+        sed -i "s/^const VERSION = \".*\"/const VERSION = \"${TAG_VERSION#v}\"/" ./version.go
+
+    - name: Commit and push
+      run: |
+        git config --global user.email "github-tracker-bot@taplytics.com"
+        git config --global user.name "taplytics-robot"
+        git checkout -b "release-${TAG_VERSION}" # TODO: remove
+        git add ./version.go
+        git commit -m "Set VERSION to ${TAG_VERSION}"
+        git push origin "release-${TAG_VERSION}" # TODO: remove

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,5 +31,7 @@ jobs:
         git config --global user.email "github-tracker-bot@taplytics.com"
         git config --global user.name "taplytics-robot"
         git add ./version.go
-        git commit -m "Set VERSION to ${TAG_VERSION}"
-        git push origin main
+        git commit -m "Release ${TAG_VERSION}"
+        git push origin HEAD:${{ github.event.release.target_commitish }}
+        git tag --annotate --force "${TAG_VERSION}"
+        git push --force origin ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published] # TODO: change to released once this workflow is tested
+    types: [released]
       
 permissions:
   contents: write
@@ -30,7 +30,6 @@ jobs:
       run: |
         git config --global user.email "github-tracker-bot@taplytics.com"
         git config --global user.name "taplytics-robot"
-        git checkout -b "release-${TAG_VERSION}" # TODO: remove
         git add ./version.go
         git commit -m "Set VERSION to ${TAG_VERSION}"
-        git push origin "release-${TAG_VERSION}" # TODO: remove
+        git push origin main


### PR DESCRIPTION
This will update the version in `version.go` as long as it matches the pattern `vN.N.N*` to the tag minus its `v` prefix. The run will fail if the tag doesn't match, so we'll have to remember to check for that.