### PR TITLE
fix casting of audienceMatch filters

### DIFF
--- a/bucketing/segmentation.go
+++ b/bucketing/segmentation.go
@@ -45,15 +45,9 @@ func doesUserPassFilter(filter BaseFilter, audiences map[string]NoIdAudience, us
 		if !ok {
 			return false
 		}
-		if amF.Validate() != nil {
-			return false
-		}
 		return filterForAudienceMatch(amF, audiences, user, clientCustomData)
 	}
 
-	if err := filter.Validate(); err != nil {
-		return false
-	}
 	return filterFunctionsBySubtype(filter.GetSubType(), user, filter, clientCustomData)
 
 }
@@ -93,9 +87,6 @@ func filterFunctionsBySubtype(subType string, user api.PopulatedUser, filter Bas
 	} else if subType == "customData" {
 		customDataFilter, ok := filter.(*CustomDataFilter)
 		if !ok {
-			return false
-		}
-		if err := customDataFilter.Validate(); err != nil {
 			return false
 		}
 		return checkCustomData(user.CombinedCustomData(), clientCustomData, customDataFilter)

--- a/bucketing/segmentation.go
+++ b/bucketing/segmentation.go
@@ -41,7 +41,7 @@ func doesUserPassFilter(filter BaseFilter, audiences map[string]NoIdAudience, us
 	} else if filter.GetType() == "optIn" {
 		return false
 	} else if filter.GetType() == "audienceMatch" {
-		amF, ok := filter.(AudienceMatchFilter)
+		amF, ok := filter.(*AudienceMatchFilter)
 		if !ok {
 			return false
 		}
@@ -58,8 +58,7 @@ func doesUserPassFilter(filter BaseFilter, audiences map[string]NoIdAudience, us
 
 }
 
-func filterForAudienceMatch(filter AudienceMatchFilter, configAudiences map[string]NoIdAudience, user api.PopulatedUser, clientCustomData map[string]interface{}) bool {
-
+func filterForAudienceMatch(filter *AudienceMatchFilter, configAudiences map[string]NoIdAudience, user api.PopulatedUser, clientCustomData map[string]interface{}) bool {
 	audiences := filter.Audiences
 	comparator := filter.GetComparator()
 

--- a/bucketing/segmentation_test.go
+++ b/bucketing/segmentation_test.go
@@ -145,7 +145,7 @@ func TestEvaluateOperator_AudienceFilterMatch(t *testing.T) {
 	}{
 		{
 			name: "audienceMatchFilter - in the audience",
-			filters: []BaseFilter{AudienceMatchFilter{
+			filters: []BaseFilter{&AudienceMatchFilter{
 				filter: filter{
 					Type:       "audienceMatch",
 					Comparator: "=",
@@ -158,7 +158,7 @@ func TestEvaluateOperator_AudienceFilterMatch(t *testing.T) {
 		},
 		{
 			name: "audienceMatchFilter - not in the audience",
-			filters: []BaseFilter{AudienceMatchFilter{
+			filters: []BaseFilter{&AudienceMatchFilter{
 				filter: filter{
 					Type:       "audienceMatch",
 					Comparator: "!=",
@@ -171,7 +171,7 @@ func TestEvaluateOperator_AudienceFilterMatch(t *testing.T) {
 		},
 		{
 			name: "audienceMatchFilter - audience ID not in list",
-			filters: []BaseFilter{AudienceMatchFilter{
+			filters: []BaseFilter{&AudienceMatchFilter{
 				filter: filter{
 					Type:       "audienceMatch",
 					Comparator: "==",
@@ -184,7 +184,7 @@ func TestEvaluateOperator_AudienceFilterMatch(t *testing.T) {
 		},
 		{
 			name: "audienceMatchFilter - audience ID not in list",
-			filters: []BaseFilter{AudienceMatchFilter{
+			filters: []BaseFilter{&AudienceMatchFilter{
 				filter: filter{
 					Type:       "audienceMatch",
 					Comparator: "==",


### PR DESCRIPTION
This fixes a bug where audienceMatch filters were being short-circuited because of a bad type cast in the segmentation logic. The unit tests didn't catch it because a non-pointer type was also provided there, instead of the pointer type that the real config would have been parsed into.
