### PR TITLE
Bump version and fix http client timeouts

### DIFF
--- a/configmanager.go
+++ b/configmanager.go
@@ -41,9 +41,13 @@ func NewEnvironmentConfigManager(
 		sdkKey:         sdkKey,
 		localBucketing: localBucketing,
 		cfg:            cfg,
-		httpClient:     &http.Client{Timeout: options.RequestTimeout},
-		hasConfig:      atomic.Bool{},
-		firstLoad:      true,
+		httpClient: &http.Client{
+			// Set an explicit timeout so that we don't wait forever on a request
+			// Use the configurable timeout because fetching the first config can block SDK initialization.
+			Timeout: options.RequestTimeout,
+		},
+		hasConfig: atomic.Bool{},
+		firstLoad: true,
 	}
 
 	configManager.context, configManager.stopPolling = context.WithCancel(context.Background())

--- a/configuration.go
+++ b/configuration.go
@@ -156,7 +156,10 @@ func NewConfiguration(options *Options) *HTTPConfiguration {
 		EventsAPIBasePath: eventsApiBasePath,
 		DefaultHeader:     make(map[string]string),
 		UserAgent:         "DevCycle-Server-SDK/" + VERSION + "/go",
-		HTTPClient:        http.DefaultClient,
+		HTTPClient: &http.Client{
+			// Set an explicit timeout so that we don't wait forever on a request
+			Timeout: options.RequestTimeout,
+		},
 	}
 	return cfg
 }

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package devcycle
 
-const VERSION = "2.10.3"
+const VERSION = "2.10.4"


### PR DESCRIPTION
I added timeouts to the HTTP clients - it's a gotcha with the Go net/http client that the client can basically block forever under some conditions if a timeout isn't set.
