### PR TITLE
fix: DVC-8025 rename DVC references to DevCycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import "github.com/devcyclehq/go-server-sdk/v2"
 ## Getting Started
 
 ```golang
-    sdkKey := os.Getenv("DVC_SERVER_KEY")
+    sdkKey := os.Getenv("DEVCYCLE_SERVER_SDK_KEY")
 	user := devcycle.User{UserId: "test"}
 
 	options := devcycle.Options{

--- a/client.go
+++ b/client.go
@@ -223,7 +223,7 @@ func createNullableCustomData(data map[string]interface{}) *proto.NullableCustom
 }
 
 /*
-DVCClientService Get all features by key for user data
+Get all features by key for user data
   - @param body
 
 @return map[string]Feature
@@ -454,7 +454,7 @@ func (c *Client) AllVariables(user User) (map[string]ReadOnlyVariable, error) {
 }
 
 /*
-DVCClientService Post events to DevCycle for user
+Post events to DevCycle for user
   - @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
   - @param body
 

--- a/client_test.go
+++ b/client_test.go
@@ -420,10 +420,10 @@ func TestClient_TrackLocal_QueueEventBeforeConfig(t *testing.T) {
 }
 
 func TestProduction_Local(t *testing.T) {
-	environmentKey := os.Getenv("DVC_SERVER_KEY")
+	environmentKey := os.Getenv("DEVCYCLE_SERVER_SDK_KEY")
 	user := User{UserId: "test"}
 	if environmentKey == "" {
-		t.Skip("DVC_SERVER_KEY not set. Not using production tests.")
+		t.Skip("DEVCYCLE_SERVER_SDK_KEY not set. Not using production tests.")
 	}
 	dvcOptions := Options{
 		EnableEdgeDB:                 false,

--- a/example/cloud/main.go
+++ b/example/cloud/main.go
@@ -9,13 +9,13 @@ import (
 )
 
 func main() {
-	sdkKey := os.Getenv("DVC_SERVER_SDK_KEY")
+	sdkKey := os.Getenv("DEVCYCLE_SERVER_SDK_KEY")
 	if sdkKey == "" {
-		log.Fatal("DVC_SERVER_SDK_KEY env var not set: set it to your SDK key")
+		log.Fatal("DEVCYCLE_SERVER_SDK_KEY env var not set: set it to your SDK key")
 	}
-	variableKey := os.Getenv("DVC_VARIABLE_KEY")
+	variableKey := os.Getenv("DEVCYCLE_VARIABLE_KEY")
 	if variableKey == "" {
-		log.Fatal("DVC_VARIABLE env var not set: set it to a variable key")
+		log.Fatal("DEVCYCLE_VARIABLE_KEY env var not set: set it to a variable key")
 	}
 	user := devcycle.User{UserId: "test"}
 	dvcOptions := devcycle.Options{

--- a/example/local/main.go
+++ b/example/local/main.go
@@ -9,13 +9,13 @@ import (
 )
 
 func main() {
-	sdkKey := os.Getenv("DVC_SERVER_SDK_KEY")
+	sdkKey := os.Getenv("DEVCYCLE_SERVER_SDK_KEY")
 	if sdkKey == "" {
-		log.Fatal("DVC_SERVER_SDK_KEY env var not set: set it to your SDK key")
+		log.Fatal("DEVCYCLE_SERVER_SDK_KEY env var not set: set it to your SDK key")
 	}
-	variableKey := os.Getenv("DVC_VARIABLE_KEY")
+	variableKey := os.Getenv("DEVCYCLE_VARIABLE_KEY")
 	if variableKey == "" {
-		log.Fatal("DVC_VARIABLE_KEY env var not set: set it to a variable key")
+		log.Fatal("DEVCYCLE_VARIABLE_KEY env var not set: set it to a variable key")
 	}
 
 	user := devcycle.User{UserId: "test"}


### PR DESCRIPTION
In concert with other SDKs, update public references of `DVC` to `DevCycle`. Most of this work has already been done, mainly just updating some environment variables.