### PR TITLE
fix: only set etag for requests after config is successfully validated and stored

### DIFF
--- a/configmanager.go
+++ b/configmanager.go
@@ -146,13 +146,13 @@ func (e *EnvironmentConfigManager) setConfigFromResponse(response *http.Response
 		return fmt.Errorf("invalid JSON data received for config")
 	}
 
-	e.configETag = response.Header.Get("Etag")
-
 	err = e.setConfig(config, e.configETag)
 
 	if err != nil {
 		return err
 	}
+
+	e.configETag = response.Header.Get("Etag")
 
 	util.Infof("Config set. ETag: %s\n", e.configETag)
 	if e.firstLoad {


### PR DESCRIPTION
- before we were storing the etag for use in future CDN requests even if the config itself was not stored due to a validation error
- reverse the order of the operations so that the config is validated and stored first, and then the etag is set if that succeeds