### PR TITLE
fix etag logic

### DIFF
--- a/configmanager.go
+++ b/configmanager.go
@@ -146,13 +146,15 @@ func (e *EnvironmentConfigManager) setConfigFromResponse(response *http.Response
 		return fmt.Errorf("invalid JSON data received for config")
 	}
 
-	err = e.setConfig(config, e.configETag)
+	etag := response.Header.Get("Etag")
+
+	err = e.setConfig(config, etag)
 
 	if err != nil {
 		return err
 	}
 
-	e.configETag = response.Header.Get("Etag")
+	e.configETag = etag
 
 	util.Infof("Config set. ETag: %s\n", e.configETag)
 	if e.firstLoad {


### PR DESCRIPTION
The last change was setting the etag that was passed to `setConfig` to be the previous etag rather than current one