### PR TITLE
chore: move all config storage and etag to localbucketing storage layer

### DIFF
--- a/client.go
+++ b/client.go
@@ -174,7 +174,7 @@ func (c *Client) GetRawConfig() (config []byte, etag string, err error) {
 		return nil, "", errors.New("cannot read raw config; config manager is nil")
 	}
 	if c.configManager.HasConfig() {
-		return c.configManager.rawConfig, c.configManager.configETag, nil
+		return c.configManager.GetRawConfig(), c.configManager.GetETag(), nil
 	}
 	return nil, "", errors.New("cannot read raw config; config manager has no config")
 }

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -56,6 +56,18 @@ func (n *NativeLocalBucketing) StoreConfig(configJSON []byte, eTag string) error
 	return nil
 }
 
+func (n *NativeLocalBucketing) GetETag() string {
+	return bucketing.GetEtag(n.sdkKey)
+}
+
+func (n *NativeLocalBucketing) GetRawConfig() []byte {
+	return bucketing.GetRawConfig(n.sdkKey)
+}
+
+func (n *NativeLocalBucketing) HasConfig() bool {
+	return bucketing.HasConfig(n.sdkKey)
+}
+
 func (n *NativeLocalBucketing) GenerateBucketedConfigForUser(user User) (ret *BucketedUserConfig, err error) {
 	populatedUser := user.GetPopulatedUserWithTime(n.platformData, DEFAULT_USER_TIME)
 	clientCustomData := bucketing.GetClientCustomData(n.sdkKey)

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -10,10 +10,24 @@ import (
 
 type recordingConfigReceiver struct {
 	configureCount int
+	etag           string
 }
 
-func (r *recordingConfigReceiver) StoreConfig([]byte, string) error {
+func (r *recordingConfigReceiver) StoreConfig(_ []byte, etag string) error {
 	r.configureCount++
+	r.etag = etag
+	return nil
+}
+
+func (r *recordingConfigReceiver) HasConfig() bool {
+	return r.configureCount > 0
+}
+
+func (r *recordingConfigReceiver) GetETag() string {
+	return r.etag
+}
+
+func (r *recordingConfigReceiver) GetRawConfig() []byte {
 	return nil
 }
 
@@ -34,10 +48,10 @@ func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
 	if localBucketing.configureCount != 1 {
 		t.Fatal("localBucketing.configureCount != 1")
 	}
-	if !manager.hasConfig.Load() {
+	if !manager.HasConfig() {
 		t.Fatal("cm.hasConfig != true")
 	}
-	if manager.configETag != "TESTING" {
+	if manager.GetETag() != "TESTING" {
 		t.Fatal("cm.configEtag != TESTING")
 	}
 }
@@ -59,7 +73,7 @@ func TestEnvironmentConfigManager_fetchConfig_retries500(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !manager.hasConfig.Load() {
+	if !manager.HasConfig() {
 		t.Fatal("cm.hasConfig != true")
 	}
 }
@@ -81,7 +95,7 @@ func TestEnvironmentConfigManager_fetchConfig_retries_errors(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !manager.hasConfig.Load() {
+	if !manager.HasConfig() {
 		t.Fatal("cm.hasConfig != true")
 	}
 }


### PR DESCRIPTION
- make sure there's one source of truth for stored configs and etags
- configmanager now does not hold etag or config data at all, and gets everything from the bucketing package
