### PR TITLE
fix: Send last modified header along with etag

### DIFF
--- a/bucketing/bucketing_test.go
+++ b/bucketing/bucketing_test.go
@@ -22,7 +22,7 @@ var (
 
 // Bucketing puts the user in the target for the first audience they match
 func TestBucketingFirstMatchingTarget(t *testing.T) {
-	config, err := newConfig(test_config, "", "")
+	config, err := newConfig(test_config, "", "", "")
 	require.NoError(t, err)
 
 	feature := config.GetFeatureForVariableId("615356f120ed334a6054564c")
@@ -53,7 +53,7 @@ func TestBucketing_RolloutGatesUser(t *testing.T) {
 		Email:  "test@email.com",
 	}.GetPopulatedUser(&api.PlatformData{})
 
-	config, err := newConfig(test_config, "", "")
+	config, err := newConfig(test_config, "", "", "")
 	require.NoError(t, err)
 
 	feature := config.GetFeatureForVariableId("61538237b0a70b58ae6af71f")
@@ -190,7 +190,7 @@ func TestBucketing_Deterministic_RolloutNotEqualBucketing(t *testing.T) {
 
 func TestConfigParsing(t *testing.T) {
 	// Parsing the large config should succeed without an error
-	err := SetConfig(test_config, "test", "etag", "rayid")
+	err := SetConfig(test_config, "test", "etag", "rayid", "lastModified")
 	require.NoError(t, err)
 	config, err := getConfig("test")
 	require.NoError(t, err)
@@ -468,7 +468,7 @@ func TestClientData(t *testing.T) {
 		PlatformVersion: "1.1.2",
 	})
 
-	err := SetConfig(test_config, "test", "", "")
+	err := SetConfig(test_config, "test", "", "", "")
 	require.NoError(t, err)
 
 	// Ensure bucketed config has a feature variation map that's empty
@@ -572,7 +572,7 @@ func TestVariableForUser(t *testing.T) {
 		PlatformVersion: "1.1.2",
 	})
 
-	err := SetConfig(test_config, "test", "", "")
+	err := SetConfig(test_config, "test", "", "", "")
 	require.NoError(t, err)
 
 	variableType, value, featureId, variationId, err := generateBucketedVariableForUser("test", user, "json-var", nil)
@@ -585,7 +585,7 @@ func TestVariableForUser(t *testing.T) {
 }
 
 func TestGenerateBucketedConfig_MissingDistribution(t *testing.T) {
-	err := SetConfig(test_broken_config, "broken_config", "", "")
+	err := SetConfig(test_broken_config, "broken_config", "", "", "")
 	require.NoError(t, err)
 
 	user := api.User{
@@ -599,7 +599,7 @@ func TestGenerateBucketedConfig_MissingDistribution(t *testing.T) {
 }
 
 func TestGenerateBucketedConfig_MissingVariations(t *testing.T) {
-	err := SetConfig(test_broken_config, "broken_config", "", "")
+	err := SetConfig(test_broken_config, "broken_config", "", "", "")
 	require.NoError(t, err)
 
 	user := api.User{
@@ -617,7 +617,7 @@ func TestGenerateBucketedConfig_MissingVariations(t *testing.T) {
 }
 
 func TestGenerateBucketedConfig_MissingVariables(t *testing.T) {
-	err := SetConfig(test_broken_config, "broken_config", "", "")
+	err := SetConfig(test_broken_config, "broken_config", "", "", "")
 	require.NoError(t, err)
 
 	user := api.User{

--- a/bucketing/config_manager_test.go
+++ b/bucketing/config_manager_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSetConfig(t *testing.T) {
-	err := SetConfig(test_config, "test", "test_etag", "rayId")
+	err := SetConfig(test_config, "test", "test_etag", "rayId", "lastModified")
 	require.NoError(t, err)
 
 	setConfig, err := getConfig("test")
@@ -16,7 +16,7 @@ func TestSetConfig(t *testing.T) {
 	baseConfig := configBody{}
 	err = json.Unmarshal(test_config, &baseConfig)
 	require.NoError(t, err)
-	baseConfig.compile("test_etag", "rayId")
+	baseConfig.compile("test_etag", "rayId", "lastModified")
 
 	require.True(t, setConfig.Equals(baseConfig))
 }
@@ -28,7 +28,7 @@ func TestGetConfig_Unset(t *testing.T) {
 }
 
 func TestGetConfig_Set(t *testing.T) {
-	err := SetConfig(test_config, "test3", "test_etag", "")
+	err := SetConfig(test_config, "test3", "test_etag", "rayId", "lastModified")
 	require.NoError(t, err)
 
 	config, err := getConfig("test3")

--- a/bucketing/event_queue_test.go
+++ b/bucketing/event_queue_test.go
@@ -18,7 +18,7 @@ func BenchmarkEventQueue_QueueEvent(b *testing.B) {
 		CustomType: "testingtype",
 		UserId:     "testing",
 	}
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(b, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{MaxEventQueueSize: b.N + 10}, (&api.PlatformData{}).Default())
 	require.NoError(b, err)
@@ -37,7 +37,7 @@ func BenchmarkEventQueue_QueueEvent_WithDrop(b *testing.B) {
 		CustomType: "testingtype",
 		UserId:     "testing",
 	}
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(b, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{MaxEventQueueSize: b.N / 2}, (&api.PlatformData{}).Default())
 	require.NoError(b, err)
@@ -52,7 +52,7 @@ func TestEventQueue_MergeAggEventQueueKeys(t *testing.T) {
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{}, (&api.PlatformData{}).Default())
 	require.NoError(t, err)
 	// Parsing the large config should succeed without an error
-	err = SetConfig(test_config, "test", "", "")
+	err = SetConfig(test_config, "test", "", "", "")
 	require.NoError(t, err)
 	config, err := getConfig("test")
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestEventQueue_FlushEvents(t *testing.T) {
 	// Test flush events by ensuring that all events are flushed
 	// and that the number of events flushed is equal to the number
 	// of events reported.
-	err := SetConfig(test_config, "test", "", "")
+	err := SetConfig(test_config, "test", "", "", "")
 	require.NoError(t, err)
 	config, err := getConfig("test")
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestEventQueue_ProcessUserEvent(t *testing.T) {
 			UserId: "testing",
 		},
 	}
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(t, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{}, (&api.PlatformData{}).Default())
 	require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestEventQueue_ProcessAggregateEvent(t *testing.T) {
 		featureId:   "featurekey",
 		variationId: "somevariation",
 	}
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(t, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{}, (&api.PlatformData{}).Default())
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestEventQueue_AddToUserQueue(t *testing.T) {
 		CustomType: "testingtype",
 		UserId:     "testing",
 	}
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(t, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{}, (&api.PlatformData{}).Default())
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestEventQueue_AddToUserQueue(t *testing.T) {
 }
 
 func TestEventQueue_AddToAggQueue(t *testing.T) {
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(t, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{FlushEventsInterval: time.Hour}, (&api.PlatformData{}).Default())
 	require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestEventQueue_UserMaxQueueDrop(t *testing.T) {
 		CustomType: "testingtype",
 		UserId:     "testing",
 	}
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(t, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{
 		DisableAutomaticEventLogging: true,
@@ -172,7 +172,7 @@ func TestEventQueue_QueueAndFlush(t *testing.T) {
 		CustomType: "testingtype",
 		UserId:     "testing",
 	}
-	err := SetConfig(test_config, "dvc_server_token_hash", "", "")
+	err := SetConfig(test_config, "dvc_server_token_hash", "", "", "")
 	require.NoError(t, err)
 	eq, err := NewEventQueue("dvc_server_token_hash", &api.EventQueueOptions{
 		FlushEventsInterval: time.Hour,

--- a/bucketing/model_config_body_test.go
+++ b/bucketing/model_config_body_test.go
@@ -131,7 +131,7 @@ func TestParseConfigBody(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := newConfig([]byte(tc.inputJSON), "", "")
+			result, err := newConfig([]byte(tc.inputJSON), "", "", "")
 
 			if tc.expectError {
 				require.Error(t, err, "Expected error, got nil")

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -53,13 +53,13 @@ func NewNativeLocalBucketing(sdkKey string, platformData *api.PlatformData, opti
 	}, err
 }
 
-func (n *NativeLocalBucketing) StoreConfig(configJSON []byte, eTag string, rayId string) error {
+func (n *NativeLocalBucketing) StoreConfig(configJSON []byte, eTag, rayId, lastModified string) error {
 	oldETag := bucketing.GetEtag(n.sdkKey)
 	_, err := n.eventQueue.FlushEventQueue(n.clientUUID, oldETag, n.GetRayId())
 	if err != nil {
 		return fmt.Errorf("Error flushing events for %s: %w", oldETag, err)
 	}
-	err = bucketing.SetConfig(configJSON, n.sdkKey, eTag, rayId, n.eventQueue)
+	err = bucketing.SetConfig(configJSON, n.sdkKey, eTag, rayId, lastModified, n.eventQueue)
 	if err != nil {
 		return fmt.Errorf("Error parsing config: %w", err)
 	}
@@ -84,6 +84,10 @@ func (n *NativeLocalBucketing) HasConfig() bool {
 
 func (n *NativeLocalBucketing) GetClientUUID() string {
 	return n.clientUUID
+}
+
+func (n *NativeLocalBucketing) GetLastModified() string {
+	return bucketing.GetLastModified(n.sdkKey)
 }
 
 func (n *NativeLocalBucketing) GenerateBucketedConfigForUser(user User) (ret *BucketedUserConfig, err error) {

--- a/client_test.go
+++ b/client_test.go
@@ -554,7 +554,7 @@ func BenchmarkClient_VariableParallel(b *testing.B) {
 			}
 			if benchmarkEnableConfigUpdates && configCounter.Add(1)%10000 == 0 {
 				go func() {
-					err = client.configManager.setConfig([]byte(test_large_config), "", "")
+					err = client.configManager.setConfig([]byte(test_large_config), "", "", "")
 					setConfigCount.Add(1)
 				}()
 			}

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -12,12 +12,14 @@ type recordingConfigReceiver struct {
 	configureCount int
 	etag           string
 	rayId          string
+	lastModified   string
 }
 
-func (r *recordingConfigReceiver) StoreConfig(_ []byte, etag string, rayId string) error {
+func (r *recordingConfigReceiver) StoreConfig(_ []byte, etag, rayId, lastModified string) error {
 	r.configureCount++
 	r.etag = etag
 	r.rayId = rayId
+	r.lastModified = lastModified
 	return nil
 }
 
@@ -35,6 +37,10 @@ func (r *recordingConfigReceiver) GetRayId() string {
 
 func (r *recordingConfigReceiver) GetRawConfig() []byte {
 	return nil
+}
+
+func (r *recordingConfigReceiver) GetLastModified() string {
+	return r.lastModified
 }
 
 func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
@@ -82,6 +88,12 @@ func TestEnvironmentConfigManager_fetchConfig_retries500(t *testing.T) {
 	if !manager.HasConfig() {
 		t.Fatal("cm.hasConfig != true")
 	}
+	if manager.GetETag() != "TESTING" {
+		t.Fatal("cm.configEtag != TESTING")
+	}
+	if manager.GetLastModified() != "LAST-MODIFIED" {
+		t.Fatal("cm.lastModified != LAST-MODIFIED")
+	}
 }
 
 func TestEnvironmentConfigManager_fetchConfig_retries_errors(t *testing.T) {
@@ -103,6 +115,12 @@ func TestEnvironmentConfigManager_fetchConfig_retries_errors(t *testing.T) {
 	}
 	if !manager.HasConfig() {
 		t.Fatal("cm.hasConfig != true")
+	}
+	if manager.GetETag() != "TESTING" {
+		t.Fatal("cm.configEtag != TESTING")
+	}
+	if manager.GetLastModified() != "LAST-MODIFIED" {
+		t.Fatal("cm.lastModified != LAST-MODIFIED")
 	}
 }
 

--- a/testing_helpers.go
+++ b/testing_helpers.go
@@ -45,6 +45,7 @@ func httpBucketingAPIMock() {
 
 			resp := httpmock.NewStringResponse(200, `{"value": true, "_id": "614ef6ea475129459160721a", "key": "test", "type": "Boolean"}`)
 			resp.Header.Set("Etag", "TESTING")
+			resp.Header.Set("Last-Modified", "LAST-MODIFIED")
 			return resp, nil
 		},
 	)
@@ -63,6 +64,7 @@ func httpCustomConfigMock(sdkKey string, respcode int, config string) httpmock.R
 	responder := func(req *http.Request) (*http.Response, error) {
 		resp := httpmock.NewStringResponse(respcode, config)
 		resp.Header.Set("Etag", "TESTING")
+		resp.Header.Set("Last-Modified", "LAST-MODIFIED")
 		return resp, nil
 	}
 	httpmock.RegisterResponder("GET", "https://config-cdn.devcycle.com/config/v1/server/"+sdkKey+".json", responder)


### PR DESCRIPTION
I really debated changing the params to be a custom object instead of having umpteen params.
