### PR TITLE
feat: SSE Config Consolidator Event Flow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/api/model_client.go
+++ b/api/model_client.go
@@ -1,0 +1,17 @@
+package api
+
+type ClientEvent struct {
+	EventType ClientEventType `json:"eventType"`
+	EventData interface{}     `json:"eventData"`
+	Status    string          `json:"status"`
+	Error     error           `json:"error"`
+}
+
+type ClientEventType string
+
+const (
+	ClientEventType_Initialized     ClientEventType = "initialized"
+	ClientEventType_Error           ClientEventType = "error"
+	ClientEventType_ConfigUpdated   ClientEventType = "configUpdated"
+	ClientEventType_RealtimeUpdates ClientEventType = "realtimeUpdates"
+)

--- a/api/model_client.go
+++ b/api/model_client.go
@@ -10,8 +10,11 @@ type ClientEvent struct {
 type ClientEventType string
 
 const (
-	ClientEventType_Initialized     ClientEventType = "initialized"
-	ClientEventType_Error           ClientEventType = "error"
-	ClientEventType_ConfigUpdated   ClientEventType = "configUpdated"
-	ClientEventType_RealtimeUpdates ClientEventType = "realtimeUpdates"
+	ClientEventType_Initialized                ClientEventType = "initialized"
+	ClientEventType_Error                      ClientEventType = "error"
+	ClientEventType_ConfigUpdated              ClientEventType = "configUpdated"
+	ClientEventType_RealtimeUpdates            ClientEventType = "realtimeUpdates"
+	ClientEventType_InternalSSEFailure         ClientEventType = "internalSSEFailure"
+	ClientEventType_InternalNewConfigAvailable ClientEventType = "internalNewConfigAvailable"
+	ClientEventType_InternalSSEConnected       ClientEventType = "internalSSEConnected"
 )

--- a/client.go
+++ b/client.go
@@ -86,7 +86,7 @@ func NewClient(sdkKey string, options *Options) (*Client, error) {
 		return nil, err
 	}
 	if !sdkKeyIsValid(sdkKey) {
-		return nil, fmt.Errorf("Invalid sdk key. Call NewClient with a valid sdk key.")
+		return nil, fmt.Errorf("invalid sdk key %s. Call NewClient with a valid sdk key", sdkKey)
 	}
 	options.CheckDefaults()
 	cfg := NewConfiguration(options)
@@ -131,12 +131,10 @@ func NewClient(sdkKey string, options *Options) (*Client, error) {
 			c.handleInitialization()
 			return c, err
 		}
-		if !c.DevCycleOptions.EnableRealtimeUpdates {
-			c.configManager.StartPolling(options.ConfigPollingIntervalMS)
-		} else {
-			c.configManager.StartSSE()
-		}
 
+		if !c.DevCycleOptions.EnableRealtimeUpdates {
+			err = c.configManager.StartPolling(options.ConfigPollingIntervalMS)
+		}
 	}
 
 	c.handleInitialization()
@@ -187,13 +185,6 @@ func (c *Client) GetRawConfig() (config []byte, etag string, err error) {
 		return c.configManager.GetRawConfig(), c.configManager.GetETag(), nil
 	}
 	return nil, "", errors.New("cannot read raw config; config manager has no config")
-}
-
-func (c *Client) GetSSE() *SSEManager {
-	if c.configManager == nil {
-		return nil
-	}
-	return c.configManager.GetSSE()
 }
 
 /*

--- a/client.go
+++ b/client.go
@@ -129,12 +129,13 @@ func NewClient(sdkKey string, options *Options) (*Client, error) {
 		} else {
 			err = c.configManager.initialFetch()
 			c.handleInitialization()
-			return c, err
 		}
 
+		// If SSE is enabled - the first config pull will trigger SSE to be started.
 		if !c.DevCycleOptions.EnableRealtimeUpdates {
 			err = c.configManager.StartPolling(options.ConfigPollingIntervalMS)
 		}
+		return c, err
 	}
 
 	c.handleInitialization()

--- a/client.go
+++ b/client.go
@@ -129,6 +129,9 @@ func NewClient(sdkKey string, options *Options) (*Client, error) {
 		} else {
 			err = c.configManager.initialFetch()
 			c.handleInitialization()
+			if err != nil {
+				return c, err
+			}
 		}
 
 		// If SSE is enabled - the first config pull will trigger SSE to be started.

--- a/client_test.go
+++ b/client_test.go
@@ -409,6 +409,9 @@ func TestClient_Validate_OnInitializedChannel_EnableCloudBucketing_Options(t *te
 	if !c.hasConfig() {
 		t.Fatal("Expected config to be loaded")
 	}
+	if c.Close() != nil {
+		t.Fatal("Expected client to be successfully closed")
+	}
 
 	dvcOptions = Options{ClientEventHandler: nil, EnableCloudBucketing: true}
 	c, err = NewClient(test_environmentKey, &dvcOptions)
@@ -417,6 +420,9 @@ func TestClient_Validate_OnInitializedChannel_EnableCloudBucketing_Options(t *te
 	if !c.isInitialized {
 		// isInitialized returns true immediately when using Cloud Bucketing.
 		t.Fatal("Expected isInitialized to be false")
+	}
+	if c.Close() != nil {
+		t.Fatal("Expected client to be successfully closed")
 	}
 
 	dvcOptions = Options{ClientEventHandler: nil, EnableCloudBucketing: false}
@@ -429,6 +435,9 @@ func TestClient_Validate_OnInitializedChannel_EnableCloudBucketing_Options(t *te
 
 	if !c.hasConfig() {
 		t.Fatal("Expected config to be loaded")
+	}
+	if c.Close() != nil {
+		t.Fatal("Expected client to be successfully closed")
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -379,18 +379,20 @@ func TestClient_LocalBucketingHandler(t *testing.T) {
 	clientEventHandler := make(chan api.ClientEvent, 10)
 	c, err := NewClient(sdkKey, &Options{ClientEventHandler: clientEventHandler})
 	fatalErr(t, err)
-	init := <-clientEventHandler
-
-	if init.EventType != api.ClientEventType_Initialized {
-		t.Fatal("Expected initialized event")
+	event1 := <-clientEventHandler
+	event2 := <-clientEventHandler
+	switch event1.EventType {
+	case api.ClientEventType_Initialized:
+		if event2.EventType != api.ClientEventType_ConfigUpdated {
+			t.Fatal("Expected config updated event and initialized events")
+		}
+	case api.ClientEventType_ConfigUpdated:
+		if event2.EventType != api.ClientEventType_Initialized {
+			t.Fatal("Expected initialized and config updated events")
+		}
 	}
 	if !c.isInitialized {
 		t.Fatal("Expected client to be initialized")
-	}
-	for event := range clientEventHandler {
-		if event.EventType == api.ClientEventType_ConfigUpdated {
-			break
-		}
 	}
 	if !c.hasConfig() {
 		t.Fatal("Expected client to have config")

--- a/client_test.go
+++ b/client_test.go
@@ -448,8 +448,7 @@ func init() {
 
 func BenchmarkClient_VariableSerial(b *testing.B) {
 	util.SetLogger(util.DiscardLogger{})
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey := generateTestSDKKey()
 	httpCustomConfigMock(sdkKey, 200, test_large_config)
 	httpEventsApiMock()
@@ -495,8 +494,7 @@ func BenchmarkClient_VariableSerial(b *testing.B) {
 
 func BenchmarkClient_VariableParallel(b *testing.B) {
 	util.SetLogger(util.DiscardLogger{})
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey := generateTestSDKKey()
 	httpCustomConfigMock(sdkKey, 200, test_large_config)
 	httpEventsApiMock()

--- a/client_test.go
+++ b/client_test.go
@@ -1,31 +1,21 @@
 package devcycle
 
 import (
-	"flag"
 	"fmt"
 	"github.com/devcyclehq/go-server-sdk/v2/api"
 	"github.com/devcyclehq/go-server-sdk/v2/util"
 	"github.com/stretchr/testify/require"
 	"io"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
 	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/jarcoal/httpmock"
 )
 
-func init() {
-	rand.NewSource(time.Now().UnixNano())
-}
-
 func TestClient_AllFeatures_Local(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	sdkKey, _ := httpConfigMock(200)
 	c, err := NewClient(sdkKey, &Options{})
 	fatalErr(t, err)
@@ -38,8 +28,6 @@ func TestClient_AllFeatures_Local(t *testing.T) {
 }
 
 func TestClient_AllVariablesLocal(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	sdkKey, _ := httpConfigMock(200)
 	c, err := NewClient(sdkKey, &Options{})
 	require.NoError(t, err)
@@ -52,9 +40,6 @@ func TestClient_AllVariablesLocal(t *testing.T) {
 }
 
 func TestClient_AllVariablesLocal_WithSpecialCharacters(t *testing.T) {
-
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	sdkKey := generateTestSDKKey()
 	httpCustomConfigMock(sdkKey, 200, test_config_special_characters_var)
 	c, err := NewClient(sdkKey, &Options{})
@@ -88,8 +73,6 @@ func TestClient_AllVariablesLocal_WithSpecialCharacters(t *testing.T) {
 }
 
 func TestClient_VariableCloud(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	sdkKey := generateTestSDKKey()
 	httpBucketingAPIMock()
 	c, err := NewClient(sdkKey, &Options{EnableCloudBucketing: true, ConfigPollingIntervalMS: 10 * time.Second})
@@ -106,8 +89,7 @@ func TestClient_VariableCloud(t *testing.T) {
 }
 
 func TestClient_VariableLocalNumber(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey := generateTestSDKKey()
 	httpCustomConfigMock(sdkKey, 200, test_large_config)
 
@@ -138,8 +120,6 @@ func TestClient_VariableLocalNumber(t *testing.T) {
 }
 
 func TestClient_VariableLocalNumberWithNilDefault(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 	sdkKey := generateTestSDKKey()
 	httpCustomConfigMock(sdkKey, 200, test_large_config)
 
@@ -169,8 +149,7 @@ func TestClient_VariableLocalNumberWithNilDefault(t *testing.T) {
 }
 
 func TestClient_VariableEventIsQueued(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey := generateTestSDKKey()
 	httpCustomConfigMock(sdkKey, 200, test_large_config)
 	httpEventsApiMock()
@@ -197,8 +176,7 @@ func TestClient_VariableEventIsQueued(t *testing.T) {
 }
 
 func TestClient_VariableLocalFlush(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{})
@@ -213,8 +191,7 @@ func TestClient_VariableLocalFlush(t *testing.T) {
 }
 
 func TestClient_VariableLocal(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{})
@@ -248,8 +225,7 @@ func TestClient_VariableLocal(t *testing.T) {
 }
 
 func TestClient_VariableLocal_UserWithCustomData(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{})
@@ -301,8 +277,7 @@ func TestClient_VariableLocal_UserWithCustomData(t *testing.T) {
 }
 
 func TestClient_VariableLocal_403(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(403)
 
 	_, err := NewClient(sdkKey, &Options{})
@@ -312,8 +287,7 @@ func TestClient_VariableLocal_403(t *testing.T) {
 }
 
 func TestClient_TrackLocal_QueueEvent(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 	dvcOptions := Options{ConfigPollingIntervalMS: 10 * time.Second}
 
@@ -333,8 +307,6 @@ func TestClient_TrackLocal_QueueEvent(t *testing.T) {
 }
 
 func TestClient_TrackLocal_QueueEventBeforeConfig(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 
 	// Config will fail to load on HTTP 500 after several retries without an error
 	sdkKey, _ := httpConfigMock(http.StatusInternalServerError)
@@ -385,8 +357,7 @@ func TestProduction_Local(t *testing.T) {
 }
 
 func TestClient_CloudBucketingHandler(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey := generateTestSDKKey()
 	httpBucketingAPIMock()
 	clientEventHandler := make(chan api.ClientEvent, 10)
@@ -403,8 +374,7 @@ func TestClient_CloudBucketingHandler(t *testing.T) {
 }
 
 func TestClient_LocalBucketingHandler(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 	clientEventHandler := make(chan api.ClientEvent, 10)
 	c, err := NewClient(sdkKey, &Options{ClientEventHandler: clientEventHandler})
@@ -439,12 +409,6 @@ var (
 	benchmarkEnableConfigUpdates bool
 	benchmarkDisableLogs         bool
 )
-
-func init() {
-	flag.BoolVar(&benchmarkEnableEvents, "benchEnableEvents", false, "Custom test flag that enables event logging in benchmarks")
-	flag.BoolVar(&benchmarkEnableConfigUpdates, "benchEnableConfigUpdates", false, "Custom test flag that enables config updates in benchmarks")
-	flag.BoolVar(&benchmarkDisableLogs, "benchDisableLogs", false, "Custom test flag that disables logging in benchmarks")
-}
 
 func BenchmarkClient_VariableSerial(b *testing.B) {
 	util.SetLogger(util.DiscardLogger{})

--- a/configmanager.go
+++ b/configmanager.go
@@ -238,8 +238,6 @@ func (e *EnvironmentConfigManager) fetchConfig(numRetriesRemaining int, minimumL
 		if e.pollingManager != nil {
 			e.pollingManager.stopPolling()
 		}
-		body, _ := io.ReadAll(resp.Body)
-		fmt.Println(body)
 		return fmt.Errorf("invalid SDK key. Aborting config polling")
 	case statusCode >= 500:
 		// Retryable Errors. Continue polling.

--- a/configmanager.go
+++ b/configmanager.go
@@ -92,7 +92,7 @@ func (e *EnvironmentConfigManager) ssePollingManager() {
 						Error:     err,
 					}
 				}
-				break
+
 			case api.ClientEventType_InternalSSEFailure:
 				// Re-enable polling until a valid config is fetched, and then re-initialize SSE.
 				e.sseManager.StopSSE()
@@ -105,12 +105,12 @@ func (e *EnvironmentConfigManager) ssePollingManager() {
 						Error:     err,
 					}
 				}
-				break
+
 			case api.ClientEventType_InternalSSEConnected:
 				if e.pollingManager != nil {
 					e.pollingManager.stopPolling()
 				}
-				break
+
 			case api.ClientEventType_ConfigUpdated:
 				if strings.Contains(event.EventData.(string), "SSE URL") {
 					// Reconnect SSE
@@ -125,7 +125,7 @@ func (e *EnvironmentConfigManager) ssePollingManager() {
 						}
 					}
 				}
-				break
+
 			}
 		}
 	}

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -46,8 +46,6 @@ func (r *recordingConfigReceiver) GetLastModified() string {
 }
 
 func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 
 	sdkKey, _ := httpConfigMock(200)
 
@@ -79,8 +77,6 @@ func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
 }
 
 func TestEnvironmentConfigManager_fetchConfig_success_sse(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 
 	sdkKey, _ := httpSSEConfigMock(200)
 	httpSSEConnectionMock()
@@ -108,8 +104,7 @@ func TestEnvironmentConfigManager_fetchConfig_success_sse(t *testing.T) {
 }
 
 func TestEnvironmentConfigManager_fetchConfig_retries500(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey := generateTestSDKKey()
 
 	error500Response := httpmock.NewStringResponder(http.StatusInternalServerError, "Internal Server Error")
@@ -136,8 +131,6 @@ func TestEnvironmentConfigManager_fetchConfig_retries500(t *testing.T) {
 }
 
 func TestEnvironmentConfigManager_fetchConfig_retries_errors(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 
 	connectionErrorResponse := httpmock.NewErrorResponder(fmt.Errorf("connection error"))
 	sdkKey := generateTestSDKKey()
@@ -164,7 +157,6 @@ func TestEnvironmentConfigManager_fetchConfig_retries_errors(t *testing.T) {
 }
 
 func TestEnvironmentConfigManager_fetchConfig_retries_errors_sse(t *testing.T) {
-	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	sdkKey := generateTestSDKKey()
 	httpSSEConnectionMock()
@@ -187,8 +179,7 @@ func TestEnvironmentConfigManager_fetchConfig_retries_errors_sse(t *testing.T) {
 }
 
 func TestEnvironmentConfigManager_fetchConfig_returns_errors(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey := generateTestSDKKey()
 	connectionErrorResponse := httpmock.NewErrorResponder(fmt.Errorf("connection error"))
 
@@ -206,8 +197,6 @@ func TestEnvironmentConfigManager_fetchConfig_returns_errors(t *testing.T) {
 }
 
 func TestEnvironmentConfigManager_fetchConfig_returns_errors_sse(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
 
 	connectionErrorResponse := httpmock.NewErrorResponder(fmt.Errorf("connection error"))
 	sdkKey := generateTestSDKKey()

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -72,9 +72,9 @@ func TestEnvironmentConfigManager_fetchConfig_success(t *testing.T) {
 		t.Fatal("cm.configEtag != TESTING")
 	}
 	event1 := <-testOptionsWithHandler.ClientEventHandler
-	if event1.EventType != api.ClientEventType_Initialized {
+	if event1.Status != "success" {
 		fmt.Println(event1)
-		t.Fatal("expected to have an event of initialized first")
+		t.Fatal("event1.Status != success")
 	}
 }
 
@@ -122,9 +122,7 @@ func TestEnvironmentConfigManager_fetchConfig_retries500(t *testing.T) {
 	manager := NewEnvironmentConfigManager(sdkKey, localBucketing, test_options, NewConfiguration(test_options))
 	defer manager.Close()
 	err := manager.initialFetch()
-	if err != nil {
-		t.Fatal(err)
-	}
+	fatalErr(t, err)
 	if !manager.HasConfig() {
 		t.Fatal("cm.hasConfig != true")
 	}

--- a/configuration.go
+++ b/configuration.go
@@ -48,7 +48,6 @@ type APIKey struct {
 
 type AdvancedOptions struct {
 	OverridePlatformData     *api.PlatformData
-	RealtimeUpdatesURI       string
 	RealtimeUpdatesTimeout   time.Duration
 	RealtimeUpdatesQueueSize int
 	RealtimeUpdatesBackoff   time.Duration
@@ -67,7 +66,7 @@ type Options struct {
 	FlushEventQueueSize          int           `json:"minEventsPerFlush,omitempty"`
 	ConfigCDNURI                 string
 	EventsAPIURI                 string
-	OnInitializedChannel         chan bool
+	ClientEventHandler           chan api.ClientEvent
 	BucketingAPIURI              string
 	Logger                       util.Logger
 	AdvancedOptions

--- a/configuration.go
+++ b/configuration.go
@@ -61,7 +61,7 @@ type Options struct {
 	RequestTimeout               time.Duration `json:"requestTimeout,omitempty"`
 	DisableAutomaticEventLogging bool          `json:"disableAutomaticEventLogging,omitempty"`
 	DisableCustomEventLogging    bool          `json:"disableCustomEventLogging,omitempty"`
-	DisableRealtimeUpdates       bool          `json:"disableServerSentEvents,omitempty"`
+	EnableRealtimeUpdates        bool          `json:"enableRealtimeUpdates,omitempty"`
 	MaxEventQueueSize            int           `json:"maxEventsPerFlush,omitempty"`
 	FlushEventQueueSize          int           `json:"minEventsPerFlush,omitempty"`
 	ConfigCDNURI                 string

--- a/event_manager.go
+++ b/event_manager.go
@@ -31,6 +31,7 @@ type EventManager struct {
 	sdkKey        string
 	options       *Options
 	cfg           *HTTPConfiguration
+	httpClient    *http.Client
 	closed        bool
 	flushStop     chan bool
 	forceFlush    chan bool
@@ -44,15 +45,15 @@ type FlushResult struct {
 
 func NewEventManager(options *Options, localBucketing InternalEventQueue, cfg *HTTPConfiguration, sdkKey string) (eventQueue *EventManager, err error) {
 	e := &EventManager{
-		flushMutex: &sync.Mutex{},
+		flushMutex:    &sync.Mutex{},
+		options:       options,
+		internalQueue: localBucketing,
+		cfg:           cfg,
+		sdkKey:        sdkKey,
+		flushStop:     make(chan bool, 1),
+		forceFlush:    make(chan bool, 1),
+		httpClient:    cfg.HTTPClient,
 	}
-	e.options = options
-	e.internalQueue = localBucketing
-	e.cfg = cfg
-	e.sdkKey = sdkKey
-
-	e.flushStop = make(chan bool, 1)
-	e.forceFlush = make(chan bool, 1)
 
 	// Disable automatic flushing of events if all sources of events are disabled
 	// DisableAutomaticEventLogging is passed into the WASM to disable events
@@ -118,7 +119,7 @@ func (e *EventManager) FlushEvents() (err error) {
 	defer e.flushMutex.Unlock()
 
 	util.Debugf("Started flushing events")
-	
+
 	defer func() {
 		if r := recover(); r != nil {
 			// get the stack trace and potentially log it here
@@ -165,7 +166,7 @@ func (e *EventManager) flushEventPayload(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err = e.cfg.HTTPClient.Do(req)
+	resp, err = e.httpClient.Do(req)
 
 	if err != nil {
 		util.Errorf("Failed to make request to events api: %s", err)

--- a/event_manager_test.go
+++ b/event_manager_test.go
@@ -11,9 +11,7 @@ import (
 )
 
 func TestEventManager_QueueEvent(t *testing.T) {
-
 	sdkKey, _ := httpConfigMock(200)
-
 	c, err := NewClient(sdkKey, &Options{})
 	fatalErr(t, err)
 	defer c.Close()

--- a/event_manager_test.go
+++ b/event_manager_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestEventManager_QueueEvent(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{})
@@ -27,8 +26,7 @@ func TestEventManager_QueueEvent(t *testing.T) {
 }
 
 func TestEventManager_QueueEvent_100_DropEvent(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{MaxEventQueueSize: 100, FlushEventQueueSize: 10})
@@ -52,8 +50,7 @@ func TestEventManager_QueueEvent_100_DropEvent(t *testing.T) {
 }
 
 func TestEventManager_QueueEvent_100_Flush(t *testing.T) {
-	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
+
 	sdkKey, _ := httpConfigMock(200)
 	httpEventsApiMock()
 	c, err := NewClient(sdkKey, &Options{

--- a/event_manager_test.go
+++ b/event_manager_test.go
@@ -13,9 +13,9 @@ import (
 func TestEventManager_QueueEvent(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
+	sdkKey, _ := httpConfigMock(200)
 
-	c, err := NewClient("dvc_server_token_hash", &Options{})
+	c, err := NewClient(sdkKey, &Options{})
 	fatalErr(t, err)
 	defer c.Close()
 
@@ -29,9 +29,9 @@ func TestEventManager_QueueEvent(t *testing.T) {
 func TestEventManager_QueueEvent_100_DropEvent(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
+	sdkKey, _ := httpConfigMock(200)
 
-	c, err := NewClient("dvc_server_token_hash", &Options{MaxEventQueueSize: 100, FlushEventQueueSize: 10})
+	c, err := NewClient(sdkKey, &Options{MaxEventQueueSize: 100, FlushEventQueueSize: 10})
 	fatalErr(t, err)
 	defer c.Close()
 
@@ -54,9 +54,9 @@ func TestEventManager_QueueEvent_100_DropEvent(t *testing.T) {
 func TestEventManager_QueueEvent_100_Flush(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
-	httpConfigMock(200)
+	sdkKey, _ := httpConfigMock(200)
 	httpEventsApiMock()
-	c, err := NewClient("dvc_server_token_hash", &Options{
+	c, err := NewClient(sdkKey, &Options{
 		MaxEventQueueSize:       100,
 		FlushEventQueueSize:     10,
 		ConfigPollingIntervalMS: time.Second,

--- a/openfeature_provider_test.go
+++ b/openfeature_provider_test.go
@@ -138,10 +138,10 @@ func Test_setCustomDataValue(t *testing.T) {
 
 func getProviderForConfig(t *testing.T, config string, cloudBucketing bool) openfeature.FeatureProvider {
 	t.Helper()
+	sdkKey := generateTestSDKKey()
+	httpCustomConfigMock(sdkKey, 200, config)
 
-	httpCustomConfigMock(test_environmentKey, 200, config)
-
-	client, err := NewClient(test_environmentKey, &Options{
+	client, err := NewClient(sdkKey, &Options{
 		EnableCloudBucketing: cloudBucketing,
 	})
 	require.NoError(t, err)

--- a/ssemanager.go
+++ b/ssemanager.go
@@ -52,7 +52,8 @@ func newSSEManager(configManager *EnvironmentConfigManager, options *Options) *S
 			}
 		},
 	}
-	sseManager.context, sseManager.stopEventHandler = context.WithCancel(context.Background())
+	sseManager.context = configManager.context
+	sseManager.stopEventHandler = configManager.shutdown
 	return sseManager
 }
 

--- a/ssemanager.go
+++ b/ssemanager.go
@@ -129,7 +129,7 @@ func (m *SSEManager) receiveSSEMessages() {
 						m.options.ClientEventHandler <- api.ClientEvent{
 							EventType: api.ClientEventType_RealtimeUpdates,
 							EventData: event,
-							Status:    "success",
+							Status:    "info",
 							Error:     nil,
 						}
 					}()
@@ -140,6 +140,7 @@ func (m *SSEManager) receiveSSEMessages() {
 					return nil
 				}
 				if message.Type_ == "refetchConfig" || message.Type_ == "" {
+					util.Debugf("SSE - Received refetchConfig message: %v\n", message)
 					m.configManager.InternalClientEvents <- api.ClientEvent{
 						EventType: api.ClientEventType_InternalNewConfigAvailable,
 						EventData: time.UnixMilli(int64(message.LastModified)),

--- a/ssemanager.go
+++ b/ssemanager.go
@@ -123,6 +123,17 @@ func (m *SSEManager) receiveSSEMessages() {
 				if !ok {
 					return nil
 				}
+
+				if m.options.ClientEventHandler != nil {
+					go func() {
+						m.options.ClientEventHandler <- api.ClientEvent{
+							EventType: api.ClientEventType_RealtimeUpdates,
+							EventData: event,
+							Status:    "success",
+							Error:     nil,
+						}
+					}()
+				}
 				message, err := m.parseMessage([]byte(event.Data()))
 				if err != nil {
 					util.Debugf("SSE - Error unmarshalling message: %v\n", err)

--- a/testing_helpers.go
+++ b/testing_helpers.go
@@ -110,4 +110,6 @@ func httpSSEConnectionMock() {
 			return resp, nil
 		},
 	)
+	responder := httpmock.NewStringResponder(200, "")
+	responder.Then(httpmock.NewStringResponder(200, sseResponseBody())).Delay(time.Second * 3)
 }

--- a/testing_helpers.go
+++ b/testing_helpers.go
@@ -25,8 +25,7 @@ var (
 
 	//go:embed testdata/fixture_small_config_sse.json
 	test_small_config_sse string
-
-	test_options = &Options{
+	test_options          = &Options{
 		// use defaults that will be set by the CheckDefaults
 		EventFlushIntervalMS:    time.Second * 30,
 		ConfigPollingIntervalMS: time.Second * 10,

--- a/testing_helpers_test.go
+++ b/testing_helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/jarcoal/httpmock"
@@ -39,7 +40,7 @@ var (
 	}
 )
 
-func init() {
+func TestMain(t *testing.M) {
 	// Remove newlines in configs
 	test_config = strings.ReplaceAll(test_config, "\n", "")
 	test_small_config_sse = strings.ReplaceAll(test_small_config_sse, "\n", "")
@@ -49,6 +50,8 @@ func init() {
 	// Set default options
 	test_options.CheckDefaults()
 	test_options_sse.CheckDefaults()
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
 }
 
 func httpBucketingAPIMock() {


### PR DESCRIPTION
- Change our test initialization strategy to do the following:
   - Never use the same sdk key - this causes a race condition in some cases due to spinning up and destroying config mocks.
   - Start and stop the mocks only once in the test overall, help prevent the race conditions on tests only.
   - Generate test SDK keys in a helper instead of the test function
- Create a threadsafe setup for handling SSE updates and polling/sse handoffs.
