### PR TITLE
fix: Ignore older config lastmodified timestamps when fetching a config.

### DIFF
--- a/client.go
+++ b/client.go
@@ -427,7 +427,9 @@ func (c *Client) Track(user User, event Event) (bool, error) {
 	if event.Type_ == "" {
 		return false, errors.New("event type is required")
 	}
-
+	if event.ClientDate.IsZero() || event.ClientDate.Before(time.UnixMilli(0)) {
+		event.ClientDate = time.Now()
+	}
 	if c.IsLocalBucketing() {
 		if c.hasConfig() {
 			err := c.eventQueue.QueueEvent(user, event)

--- a/client_test.go
+++ b/client_test.go
@@ -307,8 +307,8 @@ func TestClient_TrackLocal_QueueEventBeforeConfig(t *testing.T) {
 	sdkKey, _ := httpConfigMock(http.StatusInternalServerError)
 	dvcOptions := Options{ConfigPollingIntervalMS: 10 * time.Second}
 
+	// Expect initial retry to fail and return an error
 	c, err := NewClient(sdkKey, &dvcOptions)
-	fatalErr(t, err)
 
 	track, err := c.Track(User{UserId: "j_test", DeviceModel: "testing"}, Event{
 		Target:      "customEvent",

--- a/client_test.go
+++ b/client_test.go
@@ -43,7 +43,7 @@ func TestClient_AllVariablesLocal(t *testing.T) {
 
 func TestClient_AllVariablesLocal_WithSpecialCharacters(t *testing.T) {
 	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, test_config_special_characters_var)
+	httpCustomConfigMock(sdkKey, 200, test_config_special_characters_var, false)
 	c, err := NewClient(sdkKey, &Options{})
 	fatalErr(t, err)
 
@@ -93,7 +93,7 @@ func TestClient_VariableCloud(t *testing.T) {
 func TestClient_VariableLocalNumber(t *testing.T) {
 
 	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, test_large_config)
+	httpCustomConfigMock(sdkKey, 200, test_large_config, false)
 
 	c, err := NewClient(sdkKey, &Options{})
 	fatalErr(t, err)
@@ -123,7 +123,7 @@ func TestClient_VariableLocalNumber(t *testing.T) {
 
 func TestClient_VariableLocalNumberWithNilDefault(t *testing.T) {
 	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, test_large_config)
+	httpCustomConfigMock(sdkKey, 200, test_large_config, false)
 
 	c, err := NewClient(sdkKey, &Options{})
 	fatalErr(t, err)
@@ -152,7 +152,7 @@ func TestClient_VariableLocalNumberWithNilDefault(t *testing.T) {
 
 func TestClient_VariableEventIsQueued(t *testing.T) {
 	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, test_large_config)
+	httpCustomConfigMock(sdkKey, 200, test_large_config, false)
 	httpEventsApiMock()
 
 	c, err := NewClient(sdkKey, &Options{})
@@ -487,7 +487,7 @@ func BenchmarkClient_VariableSerial(b *testing.B) {
 	util.SetLogger(util.DiscardLogger{})
 
 	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, test_large_config)
+	httpCustomConfigMock(sdkKey, 200, test_large_config, false)
 
 	if benchmarkDisableLogs {
 		log.SetOutput(io.Discard)
@@ -532,7 +532,7 @@ func BenchmarkClient_VariableParallel(b *testing.B) {
 	util.SetLogger(util.DiscardLogger{})
 
 	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, test_large_config)
+	httpCustomConfigMock(sdkKey, 200, test_large_config, false)
 
 	if benchmarkDisableLogs {
 		log.SetOutput(io.Discard)

--- a/client_test.go
+++ b/client_test.go
@@ -20,12 +20,11 @@ import (
 func TestClient_AllFeatures_Local(t *testing.T) {
 	sdkKey, _ := httpConfigMock(200)
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
+	require.NoError(t, err)
 
 	features, err := c.AllFeatures(
 		User{UserId: "j_test", DeviceModel: "testing"})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	fmt.Println(features)
 }
 
@@ -45,12 +44,10 @@ func TestClient_AllVariablesLocal_WithSpecialCharacters(t *testing.T) {
 	sdkKey := generateTestSDKKey()
 	httpCustomConfigMock(sdkKey, 200, test_config_special_characters_var, false)
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	variables, err := c.AllVariables(
 		User{UserId: "j_test", DeviceModel: "testing"})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	fmt.Println(variables)
 	if len(variables) != 1 {
 		t.Error("Expected 1 variable, got", len(variables))
@@ -78,15 +75,14 @@ func TestClient_VariableCloud(t *testing.T) {
 	sdkKey := generateTestSDKKey()
 	httpBucketingAPIMock()
 	c, err := NewClient(sdkKey, &Options{EnableCloudBucketing: true, ConfigPollingIntervalMS: 10 * time.Second})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	user := User{UserId: "j_test", DeviceModel: "testing"}
 	variable, err := c.Variable(user, "test", true)
-	fatalErr(t, err)
+	require.NoError(t, err)
 	fmt.Println(variable)
 
 	variableValue, err := c.VariableValue(user, "test", true)
-	fatalErr(t, err)
+	require.NoError(t, err)
 	fmt.Println(variableValue)
 }
 
@@ -96,13 +92,11 @@ func TestClient_VariableLocalNumber(t *testing.T) {
 	httpCustomConfigMock(sdkKey, 200, test_large_config, false)
 
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	user := User{UserId: "dontcare", DeviceModel: "testing", CustomData: map[string]interface{}{"data-key-7": "3yejExtXkma4"}}
 	fmt.Println(c.AllVariables(user))
 	variable, err := c.Variable(user, "v-key-76", 69)
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	if variable.IsDefaulted || variable.Value == 69 {
 		t.Fatal("variable should not be defaulted")
 	}
@@ -114,7 +108,7 @@ func TestClient_VariableLocalNumber(t *testing.T) {
 	fmt.Println(variable)
 
 	variableValue, err := c.VariableValue(user, "v-key-76", 69)
-	fatalErr(t, err)
+	require.NoError(t, err)
 	if variableValue.(float64) != 60.0 {
 		t.Fatal("variableValue should be 60")
 	}
@@ -126,15 +120,13 @@ func TestClient_VariableLocalNumberWithNilDefault(t *testing.T) {
 	httpCustomConfigMock(sdkKey, 200, test_large_config, false)
 
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	user := User{UserId: "dontcare", DeviceModel: "testing", CustomData: map[string]interface{}{"data-key-7": "3yejExtXkma4"}}
 	fmt.Println(c.AllVariables(user))
 	variable, err := c.Variable(
 		user,
 		"v-key-76", nil)
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	if variable.IsDefaulted || variable.Value == nil {
 		t.Fatal("variable should not be defaulted")
 	}
@@ -146,7 +138,7 @@ func TestClient_VariableLocalNumberWithNilDefault(t *testing.T) {
 	fmt.Println(variable)
 
 	variable, err = c.Variable(user, "nonsense-key", nil)
-	fatalErr(t, err)
+	require.NoError(t, err)
 	fmt.Println(variable)
 }
 
@@ -156,13 +148,11 @@ func TestClient_VariableEventIsQueued(t *testing.T) {
 	httpEventsApiMock()
 
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	user := User{UserId: "dontcare", DeviceModel: "testing", CustomData: map[string]interface{}{"data-key-7": "3yejExtXkma4"}}
 	fmt.Println(c.AllVariables(user))
 	variable, err := c.Variable(user, "v-key-76", 69)
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	if variable.IsDefaulted || variable.Value == 69 {
 		t.Fatal("variable should not be defaulted")
 	}
@@ -180,13 +170,12 @@ func TestClient_VariableLocalFlush(t *testing.T) {
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	user := User{UserId: "j_test", DeviceModel: "testing"}
 	variable, err := c.Variable(user, "variableThatShouldBeDefaulted", true)
-	fatalErr(t, err)
+	require.NoError(t, err)
 	err = c.FlushEvents()
-	fatalErr(t, err)
+	require.NoError(t, err)
 	fmt.Println(variable)
 }
 
@@ -194,12 +183,10 @@ func TestClient_VariableLocal(t *testing.T) {
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	user := User{UserId: "j_test", DeviceModel: "testing"}
 	variable, err := c.Variable(user, "test", true)
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	expected := Variable{
 		BaseVariable: BaseVariable{
 			Key:   "test",
@@ -217,7 +204,7 @@ func TestClient_VariableLocal(t *testing.T) {
 	fmt.Println(variable)
 
 	variableValue, err := c.VariableValue(user, "test", true)
-	fatalErr(t, err)
+	require.NoError(t, err)
 	if variableValue != true {
 		t.Fatal("Expected variableValue to be true")
 	}
@@ -227,8 +214,7 @@ func TestClient_VariableLocal_UserWithCustomData(t *testing.T) {
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	customData := map[string]interface{}{
 		"propStr":  "hello",
 		"propInt":  1,
@@ -249,8 +235,7 @@ func TestClient_VariableLocal_UserWithCustomData(t *testing.T) {
 		PrivateCustomData: customPrivateData,
 	}
 	variable, err := c.Variable(user, "test", true)
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	expected := Variable{
 		BaseVariable: BaseVariable{
 			Key:   "test",
@@ -268,7 +253,7 @@ func TestClient_VariableLocal_UserWithCustomData(t *testing.T) {
 	fmt.Println(variable)
 
 	variableValue, err := c.VariableValue(user, "test", true)
-	fatalErr(t, err)
+	require.NoError(t, err)
 	if variableValue != true {
 		t.Fatal("Expected variableValue to be true")
 	}
@@ -287,8 +272,7 @@ func TestClient_TrackLocal_QueueEvent(t *testing.T) {
 	dvcOptions := Options{ConfigPollingIntervalMS: 10 * time.Second}
 
 	c, err := NewClient(sdkKey, &dvcOptions)
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	track, err := c.Track(User{UserId: "j_test", DeviceModel: "testing"}, Event{
 		Target:      "customEvent",
 		Value:       0,
@@ -296,8 +280,7 @@ func TestClient_TrackLocal_QueueEvent(t *testing.T) {
 		FeatureVars: nil,
 		MetaData:    nil,
 	})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	fmt.Println(track)
 }
 
@@ -309,7 +292,7 @@ func TestClient_TrackLocal_QueueEventBeforeConfig(t *testing.T) {
 
 	// Expect initial retry to fail and return an error
 	c, err := NewClient(sdkKey, &dvcOptions)
-
+	require.NoError(t, err)
 	track, err := c.Track(User{UserId: "j_test", DeviceModel: "testing"}, Event{
 		Target:      "customEvent",
 		Value:       0,
@@ -317,8 +300,7 @@ func TestClient_TrackLocal_QueueEventBeforeConfig(t *testing.T) {
 		FeatureVars: nil,
 		MetaData:    nil,
 	})
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	fmt.Println(track)
 }
 
@@ -339,13 +321,10 @@ func TestProduction_Local(t *testing.T) {
 		DisableCustomEventLogging:    false,
 	}
 	client, err := NewClient(environmentKey, &dvcOptions)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	variables, err := client.AllVariables(user)
-	fatalErr(t, err)
-
+	require.NoError(t, err)
 	if len(variables) == 0 {
 		t.Fatal("No variables returned")
 	}
@@ -357,7 +336,7 @@ func TestClient_CloudBucketingHandler(t *testing.T) {
 	httpBucketingAPIMock()
 	clientEventHandler := make(chan api.ClientEvent, 10)
 	c, err := NewClient(sdkKey, &Options{EnableCloudBucketing: true, ClientEventHandler: clientEventHandler})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	init := <-clientEventHandler
 
 	if init.EventType != api.ClientEventType_Initialized {
@@ -373,7 +352,7 @@ func TestClient_LocalBucketingHandler(t *testing.T) {
 	sdkKey, _ := httpConfigMock(200)
 	clientEventHandler := make(chan api.ClientEvent, 10)
 	c, err := NewClient(sdkKey, &Options{ClientEventHandler: clientEventHandler})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	event1 := <-clientEventHandler
 	event2 := <-clientEventHandler
 	switch event1.EventType {
@@ -409,7 +388,7 @@ func TestClient_ConfigUpdatedEvent(t *testing.T) {
 	httpmock.RegisterResponder("POST", "https://config-updated.devcycle.com/v1/events/batch", responder)
 	sdkKey, _ := httpConfigMock(200)
 	c, err := NewClient(sdkKey, &Options{EventsAPIURI: "https://config-updated.devcycle.com", EventFlushIntervalMS: 500 * time.Millisecond})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	if !c.isInitialized {
 		t.Fatal("Expected client to be initialized")
 	}
@@ -435,7 +414,7 @@ func TestClient_ConfigUpdatedEvent_Detail(t *testing.T) {
 	}
 	httpmock.RegisterResponder("POST", "https://config-updated.devcycle.com/v1/events/batch", responder)
 	c, err := NewClient(sdkKey, &Options{EventsAPIURI: "https://config-updated.devcycle.com", EventFlushIntervalMS: 500 * time.Millisecond})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	if !c.isInitialized {
 		t.Fatal("Expected client to be initialized")
 	}
@@ -463,7 +442,7 @@ func TestClient_ConfigUpdatedEvent_VariableEval(t *testing.T) {
 	}
 	httpmock.RegisterResponder("POST", "https://config-updated.devcycle.com/v1/events/batch", responder)
 	c, err := NewClient(sdkKey, &Options{EventsAPIURI: "https://config-updated.devcycle.com", EventFlushIntervalMS: time.Millisecond * 500})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	if !c.isInitialized {
 		t.Fatal("Expected client to be initialized")
 	}

--- a/configmanager.go
+++ b/configmanager.go
@@ -225,7 +225,7 @@ func (e *EnvironmentConfigManager) fetchConfig(numRetriesRemaining int, minimumL
 	if lastModified != "" {
 		req.Header.Set("If-Modified-Since", lastModified)
 	}
-	if etag != "" && e.options.EnableETagMatching {
+	if etag != "" && !e.options.DisableETagMatching {
 		req.Header.Set("If-None-Match", etag)
 	}
 

--- a/configmanager.go
+++ b/configmanager.go
@@ -200,6 +200,9 @@ func (e *EnvironmentConfigManager) initialFetch() error {
 }
 
 func (e *EnvironmentConfigManager) fetchConfig(numRetriesRemaining int, minimumLastModified ...time.Time) (err error) {
+	if numRetriesRemaining < 0 {
+		return fmt.Errorf("retries exhausted")
+	}
 	util.Debugf("Fetching config. Retries remaining: %d\n", numRetriesRemaining)
 	defer func() {
 		if r := recover(); r != nil {

--- a/configmanager.go
+++ b/configmanager.go
@@ -187,6 +187,12 @@ func (e *EnvironmentConfigManager) StartPolling(interval time.Duration) {
 			case <-e.pollingManager.ticker.C:
 				err := e.fetchConfig(CONFIG_RETRIES)
 				if err != nil {
+					e.InternalClientEvents <- api.ClientEvent{
+						EventType: api.ClientEventType_Error,
+						EventData: "Error fetching config: " + err.Error(),
+						Status:    "error",
+						Error:     err,
+					}
 					util.Warnf("Error fetching config: %s\n", err)
 				}
 			}

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -140,7 +140,7 @@ func TestEnvironmentConfigManager_fetchConfig_refuseOld(t *testing.T) {
 			return true
 		}
 		return false
-	}, 3*time.Second, 500*time.Millisecond)
+	}, 2*time.Second, 500*time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		return manager.GetLastModified() == newestHeaders["Last-Modified"]

--- a/configmanager_test.go
+++ b/configmanager_test.go
@@ -167,7 +167,7 @@ func TestEnvironmentConfigManager_fetchConfig_success_sse(t *testing.T) {
 	manager, _ := NewEnvironmentConfigManager(sdkKey, localBucketing, nil, test_options_sse, NewConfiguration(test_options_sse))
 	defer manager.Close()
 	err := manager.initialFetch()
-	fatalErr(t, err)
+	require.NoError(t, err)
 	if localBucketing.configureCount != 1 {
 		t.Fatal("localBucketing.configureCount != 1")
 	}
@@ -309,7 +309,7 @@ func TestEnvironmentConfigManager_fetchConfig_retries_errors_sse(t *testing.T) {
 	manager, _ := NewEnvironmentConfigManager(sdkKey, localBucketing, nil, test_options_sse, NewConfiguration(test_options_sse))
 	defer manager.Close()
 	err := manager.initialFetch()
-	fatalErr(t, err)
+	require.NoError(t, err)
 
 	if !manager.HasConfig() {
 		t.Fatal("cm.hasConfig != true")

--- a/configuration.go
+++ b/configuration.go
@@ -26,6 +26,7 @@ type Options struct {
 	RequestTimeout               time.Duration `json:"requestTimeout,omitempty"`
 	DisableAutomaticEventLogging bool          `json:"disableAutomaticEventLogging,omitempty"`
 	DisableCustomEventLogging    bool          `json:"disableCustomEventLogging,omitempty"`
+	EnableETagMatching           bool          `json:"enableETagMatching,omitempty"`
 	EnableBetaRealtimeUpdates    bool          `json:"enableRealtimeUpdates,omitempty"`
 	MaxEventQueueSize            int           `json:"maxEventsPerFlush,omitempty"`
 	FlushEventQueueSize          int           `json:"minEventsPerFlush,omitempty"`

--- a/configuration.go
+++ b/configuration.go
@@ -26,7 +26,7 @@ type Options struct {
 	RequestTimeout               time.Duration `json:"requestTimeout,omitempty"`
 	DisableAutomaticEventLogging bool          `json:"disableAutomaticEventLogging,omitempty"`
 	DisableCustomEventLogging    bool          `json:"disableCustomEventLogging,omitempty"`
-	EnableETagMatching           bool          `json:"enableETagMatching,omitempty"`
+	DisableETagMatching          bool          `json:"disableETagMatching,omitempty"`
 	EnableBetaRealtimeUpdates    bool          `json:"enableRealtimeUpdates,omitempty"`
 	MaxEventQueueSize            int           `json:"maxEventsPerFlush,omitempty"`
 	FlushEventQueueSize          int           `json:"minEventsPerFlush,omitempty"`

--- a/event_manager.go
+++ b/event_manager.go
@@ -126,10 +126,11 @@ func (e *EventManager) QueueSDKConfigEvent(req http.Request, resp http.Response)
 	user := api.User{UserId: fmt.Sprintf("%s@%s", uuid, hostname)}
 
 	event := api.Event{
-		Type_:  api.EventType_SDKConfig,
-		UserId: user.UserId,
-		Target: fmt.Sprintf("%s://%s%s", req.URL.Scheme, req.URL.Host, req.URL.Path),
-		Value:  -1,
+		ClientDate: time.Now(),
+		Type_:      api.EventType_SDKConfig,
+		UserId:     user.UserId,
+		Target:     fmt.Sprintf("%s://%s%s", req.URL.Scheme, req.URL.Host, req.URL.Path),
+		Value:      -1,
 		MetaData: map[string]interface{}{
 			"clientUUID":      uuid,
 			"reqEtag":         req.Header.Get("If-None-Match"),

--- a/event_manager_test.go
+++ b/event_manager_test.go
@@ -14,7 +14,7 @@ import (
 func TestEventManager_QueueEvent(t *testing.T) {
 	sdkKey, _ := httpConfigMock(200)
 	c, err := NewClient(sdkKey, &Options{})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	defer c.Close()
 
 	_, err = c.Track(User{UserId: "j_test", DeviceModel: "testing"},
@@ -29,7 +29,7 @@ func TestEventManager_QueueEvent_100_DropEvent(t *testing.T) {
 	sdkKey, _ := httpConfigMock(200)
 
 	c, err := NewClient(sdkKey, &Options{MaxEventQueueSize: 100, FlushEventQueueSize: 10})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	defer c.Close()
 
 	errored := false
@@ -56,7 +56,7 @@ func TestEventManager_QueueEvent_100_Flush(t *testing.T) {
 		ConfigPollingIntervalMS: time.Second,
 		EventFlushIntervalMS:    time.Second,
 	})
-	fatalErr(t, err)
+	require.NoError(t, err)
 	defer c.Close()
 	require.Eventually(t, func() bool {
 		return c.isInitialized && c.hasConfig()

--- a/openfeature_provider_test.go
+++ b/openfeature_provider_test.go
@@ -144,7 +144,7 @@ func getProviderForConfig(t *testing.T, cloudBucketing bool) openfeature.Feature
 func getProviderForCustomConfig(t *testing.T, config string, cloudBucketing bool) openfeature.FeatureProvider {
 	t.Helper()
 	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, config)
+	httpCustomConfigMock(sdkKey, 200, config, false)
 
 	client, err := NewClient(sdkKey, &Options{
 		EnableCloudBucketing: cloudBucketing,

--- a/testing_helpers_test.go
+++ b/testing_helpers_test.go
@@ -151,10 +151,3 @@ func httpSSEConnectionMock() {
 func generateTestSDKKey() string {
 	return "dvc_server_TESTING" + strconv.FormatInt(rand.Int63(), 10) + "_hash"
 }
-
-func fatalErr(t *testing.T, err error) {
-	t.Helper()
-	if err != nil {
-		t.Fatal(err)
-	}
-}

--- a/testing_helpers_test.go
+++ b/testing_helpers_test.go
@@ -87,19 +87,28 @@ func httpEventsApiMock() {
 
 func httpConfigMock(respcode int) (sdkKey string, responder httpmock.Responder) {
 	sdkKey = generateTestSDKKey()
-	responder = httpCustomConfigMock(sdkKey, respcode, test_config)
+	responder = httpCustomConfigMock(sdkKey, respcode, test_config, false)
 	return
 }
 
-func httpCustomConfigMock(sdkKey string, respcode int, config string) httpmock.Responder {
+func httpCustomConfigMock(sdkKey string, respcode int, config string, skipRegister bool, headers ...map[string]string) httpmock.Responder {
 	responder := func(req *http.Request) (*http.Response, error) {
 		resp := httpmock.NewStringResponse(respcode, config)
-		resp.Header.Set("Etag", "TESTING")
-		resp.Header.Set("Last-Modified", "LAST-MODIFIED")
-		resp.Header.Set("Cf-Ray", "TESTING")
+		if len(headers) > 0 {
+			for k, v := range headers[0] {
+				resp.Header.Set(k, v)
+			}
+		} else {
+			resp.Header.Set("Etag", "TESTING")
+			resp.Header.Set("Last-Modified", "LAST-MODIFIED")
+			resp.Header.Set("Cf-Ray", "TESTING")
+		}
+
 		return resp, nil
 	}
-	httpmock.RegisterResponder("GET", "https://config-cdn.devcycle.com/config/v1/server/"+sdkKey+".json", responder)
+	if !skipRegister {
+		httpmock.RegisterResponder("GET", "https://config-cdn.devcycle.com/config/v1/server/"+sdkKey+".json", responder)
+	}
 	return responder
 }
 
@@ -109,7 +118,7 @@ func httpSSEConfigMock(respCode int, sdkKeys ...string) (sdkKey string, responde
 	} else {
 		sdkKey = sdkKeys[0]
 	}
-	responder = httpCustomConfigMock(sdkKey, respCode, test_small_config_sse)
+	responder = httpCustomConfigMock(sdkKey, respCode, test_small_config_sse, false)
 	return
 }
 

--- a/testing_helpers_test.go
+++ b/testing_helpers_test.go
@@ -74,7 +74,7 @@ func httpBucketingAPIMock() {
 
 			resp := httpmock.NewStringResponse(200, `{"value": true, "_id": "614ef6ea475129459160721a", "key": "test", "type": "Boolean"}`)
 			resp.Header.Set("Etag", "TESTING")
-			resp.Header.Set("Last-Modified", "LAST-MODIFIED")
+			resp.Header.Set("Last-Modified", time.Now().Add(-time.Second*2).Format(time.RFC1123Z))
 			return resp, nil
 		},
 	)
@@ -100,7 +100,7 @@ func httpCustomConfigMock(sdkKey string, respcode int, config string, skipRegist
 			}
 		} else {
 			resp.Header.Set("Etag", "TESTING")
-			resp.Header.Set("Last-Modified", "LAST-MODIFIED")
+			resp.Header.Set("Last-Modified", time.Now().Add(-time.Second*2).Format(time.RFC1123))
 			resp.Header.Set("Cf-Ray", "TESTING")
 		}
 


### PR DESCRIPTION
Also set clientdate on sdkconfig events, and regular tracked events.
