### PR TITLE
feat: Add support for alternate key bucketing

### DIFF
--- a/api/model_public_project.go
+++ b/api/model_public_project.go
@@ -8,9 +8,9 @@ type Project struct {
 }
 
 type ProjectSettings struct {
-	EdgeDB EdgeDBSettings `json:"edgeDB"`
-	OptIn  OptInSettings  `json:"optIn"`
-	DisablePassthroughRollouts bool `json:"disablePassthroughRollouts"` 
+	EdgeDB                     EdgeDBSettings `json:"edgeDB"`
+	OptIn                      OptInSettings  `json:"optIn"`
+	DisablePassthroughRollouts bool           `json:"disablePassthroughRollouts"`
 }
 
 type EdgeDBSettings struct {

--- a/bucketing/bucketing.go
+++ b/bucketing/bucketing.go
@@ -60,7 +60,8 @@ func determineUserBucketingValueForTarget(targetBucketingKey, userId string, mer
 			return strconv.FormatFloat(v, 'f', -1, 64)
 		case string:
 			return v
-		// For Boolean and other types, we will return the defaultBucketingValue of "null"
+		case bool:
+			return strconv.FormatBool(v)
 		default:
 			return defaultBucketingValue
 		}

--- a/bucketing/bucketing_test.go
+++ b/bucketing/bucketing_test.go
@@ -16,6 +16,9 @@ var (
 	//go:embed testdata/fixture_test_config.json
 	test_config []byte
 
+	//go:embed testdata/fixture_test_v2_config.json
+	test_v2_config []byte
+
 	//go:embed testdata/fixture_test_broken_config.json
 	test_broken_config []byte
 
@@ -746,13 +749,13 @@ func TestBucketing_Deterministic_AlternateKeyRandomDistribution(t *testing.T) {
 	user4 := api.User{
 		UserId: "client_test_3",
 		CustomData: map[string]interface{}{
-			"favouriteNull":  nil,
+			"favouriteNull": nil,
 		},
 	}.GetPopulatedUser(&api.PlatformData{
 		PlatformVersion: "1.1.2",
 	})
 
-	err := SetConfig(test_config, "test", "", "", "")
+	err := SetConfig(test_v2_config, "test", "", "", "")
 	require.NoError(t, err)
 
 	// Check if users with the same alternate bucketing key get the same variation
@@ -777,7 +780,7 @@ func TestBucketing_Deterministic_AlternateKeyRollout(t *testing.T) {
 		CustomData: map[string]interface{}{
 			"favouriteFood": "cake",
 			"favouriteNull": nil,
-			"numericId": 123,
+			"numericId":     123,
 		},
 	}.GetPopulatedUser(&api.PlatformData{
 		PlatformVersion: "1.1.2",
@@ -787,7 +790,7 @@ func TestBucketing_Deterministic_AlternateKeyRollout(t *testing.T) {
 		CustomData: map[string]interface{}{
 			"favouriteFood": "cake",
 			"favouriteNull": nil,
-			"numericId": 123,
+			"numericId":     123,
 		},
 	}.GetPopulatedUser(&api.PlatformData{
 		PlatformVersion: "1.1.2",
@@ -797,7 +800,7 @@ func TestBucketing_Deterministic_AlternateKeyRollout(t *testing.T) {
 		CustomData: map[string]interface{}{
 			"favouriteFood": nil,
 			"favouriteNull": nil,
-			"numericId": nil,
+			"numericId":     nil,
 		},
 	}.GetPopulatedUser(&api.PlatformData{
 		PlatformVersion: "1.1.2",
@@ -805,13 +808,13 @@ func TestBucketing_Deterministic_AlternateKeyRollout(t *testing.T) {
 	user4 := api.User{
 		UserId: "client_test_3",
 		CustomData: map[string]interface{}{
-			"favouriteNull":  nil,
+			"favouriteNull": nil,
 		},
 	}.GetPopulatedUser(&api.PlatformData{
 		PlatformVersion: "1.1.2",
 	})
 
-	err := SetConfig(test_config, "test", "", "", "")
+	err := SetConfig(test_v2_config, "test", "", "", "")
 	require.NoError(t, err)
 
 	// Check if users with the same alternate bucketing key get the same variation

--- a/bucketing/bucketing_test.go
+++ b/bucketing/bucketing_test.go
@@ -718,7 +718,7 @@ func TestGenerateBucketedConfig_MissingVariables(t *testing.T) {
 	require.ErrorIs(t, err, ErrMissingVariable)
 }
 
-func TestBucketing_Deterministic_AlternateKeyRandomDistribution(t *testing.T) {
+func TestBucketing_Deterministic_StringAlternateKeyRandomDistribution(t *testing.T) {
 	user := api.User{
 		UserId: "client-test",
 		CustomData: map[string]interface{}{
@@ -774,7 +774,7 @@ func TestBucketing_Deterministic_AlternateKeyRandomDistribution(t *testing.T) {
 	require.Equal(t, bucketedUserConfig3.FeatureVariationMap["614ef8aa475928459060721d"], bucketedUserConfig4.FeatureVariationMap["614ef8aa475928459060721d"])
 }
 
-func TestBucketing_Deterministic_AlternateKeyRollout(t *testing.T) {
+func TestBucketing_Deterministic_NumberAlternateKeyRollout(t *testing.T) {
 	user := api.User{
 		UserId: "client-test",
 		CustomData: map[string]interface{}{
@@ -831,4 +831,63 @@ func TestBucketing_Deterministic_AlternateKeyRollout(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, bucketedUserConfig3.FeatureVariationMap["614ef8aa475928459060721e"], bucketedUserConfig4.FeatureVariationMap["614ef8aa475928459060721e"])
+}
+
+func TestBucketing_Deterministic_BooleanAlternateKeyRandomDistribution(t *testing.T) {
+	user := api.User{
+		UserId: "client-test",
+		CustomData: map[string]interface{}{
+			"favouriteFood": "cake",
+			"favouriteNull": nil,
+			"isSubscriber":  true,
+		},
+	}.GetPopulatedUser(&api.PlatformData{
+		PlatformVersion: "1.1.2",
+	})
+	user2 := api.User{
+		UserId: "client_test_2",
+		CustomData: map[string]interface{}{
+			"favouriteFood": "cake",
+			"favouriteNull": nil,
+			"isSubscriber":  true,
+		},
+	}.GetPopulatedUser(&api.PlatformData{
+		PlatformVersion: "1.1.2",
+	})
+	user3 := api.User{
+		UserId: "client_test_3",
+		CustomData: map[string]interface{}{
+			"favouriteFood": nil,
+			"favouriteNull": nil,
+			"isSubscriber":  nil,
+		},
+	}.GetPopulatedUser(&api.PlatformData{
+		PlatformVersion: "1.1.2",
+	})
+	user4 := api.User{
+		UserId: "client_test_3",
+		CustomData: map[string]interface{}{
+			"favouriteNull": nil,
+		},
+	}.GetPopulatedUser(&api.PlatformData{
+		PlatformVersion: "1.1.2",
+	})
+
+	err := SetConfig(test_v2_config, "test", "", "", "")
+	require.NoError(t, err)
+
+	// Check if users with the same alternate bucketing key get the same variation
+	bucketedUserConfig, err := GenerateBucketedConfig("test", user, nil)
+	require.NoError(t, err)
+	bucketedUserConfig2, err := GenerateBucketedConfig("test", user2, nil)
+	require.NoError(t, err)
+	require.Equal(t, bucketedUserConfig.FeatureVariationMap["614ef8aa475928459060721f"], bucketedUserConfig2.FeatureVariationMap["614ef8aa475928459060721f"])
+
+	// Check if users with explicitly null or missing alternate bucketing key get the same variation
+	bucketedUserConfig3, err := GenerateBucketedConfig("test", user3, nil)
+	require.NoError(t, err)
+	bucketedUserConfig4, err := GenerateBucketedConfig("test", user4, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, bucketedUserConfig3.FeatureVariationMap["614ef8aa475928459060721f"], bucketedUserConfig4.FeatureVariationMap["614ef8aa475928459060721f"])
 }

--- a/bucketing/model_target.go
+++ b/bucketing/model_target.go
@@ -9,6 +9,7 @@ type Target struct {
 	Audience     *Audience            `json:"_audience"`
 	Rollout      *Rollout             `json:"rollout"`
 	Distribution []TargetDistribution `json:"distribution"`
+	BucketingKey string			   	  `json:"bucketingKey"`
 }
 
 func (t *Target) DecideTargetVariation(boundedHash float64) (string, error) {

--- a/bucketing/model_target.go
+++ b/bucketing/model_target.go
@@ -9,7 +9,7 @@ type Target struct {
 	Audience     *Audience            `json:"_audience"`
 	Rollout      *Rollout             `json:"rollout"`
 	Distribution []TargetDistribution `json:"distribution"`
-	BucketingKey string			   	  `json:"bucketingKey"`
+	BucketingKey string               `json:"bucketingKey"`
 }
 
 func (t *Target) DecideTargetVariation(boundedHash float64) (string, error) {

--- a/bucketing/testdata/fixture_test_config.json
+++ b/bucketing/testdata/fixture_test_config.json
@@ -631,6 +631,75 @@
           ]
         }
       ]
+    },
+    {
+      "_id": "614ef8aa475928459060721e",
+      "type": "permission",
+      "key": "feature_access",
+      "configuration": {
+        "_id": "61536f62502d80fff97ed642",
+        "targets": [
+          {
+            "_id": "61536f468fd67f0091982533",
+            "_audience": {
+              "filters": {
+                "filters": [
+                  {
+                    "type": "all",
+                    "subType": "",
+                    "comparator": "",
+                    "values": []
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "distribution": [
+              {
+                "_variation": "615382338424cb11646d9671",
+                "percentage": 1
+              }
+            ],
+            "rollout": {
+              "type": "gradual",
+              "startPercentage": 0,
+              "startDate": "2024-04-05T17:58:32.318Z",
+              "stages": [
+                {
+                  "type": "linear",
+                  "percentage": 1,
+                  "date": "2034-04-07T17:58:32.319Z"
+                }
+              ]
+            },
+            "bucketingKey": "numericId"
+          }
+        ]
+      },
+      "variations": [
+        {
+          "_id": "615382338424cb11646d9671",
+          "name": "Has Access",
+          "key": "has-access",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71g",
+              "value": true
+            }
+          ]
+        },
+        {
+          "_id": "615382338424cb11646d9672",
+          "name": "No Access",
+          "key": "no-access",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71g",
+              "value": false
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": [
@@ -687,7 +756,12 @@
     {
       "_id": "61538937b0a70b58ae6af71x",
       "type": "String",
-      "key": "experiment1Var"
+      "key": "experiment_var"
+    },
+    {
+      "_id": "61538937b0a70b58ae6af71g",
+      "type": "Boolean",
+      "key": "new_feature"
     }
   ],
   "variableHashes": {

--- a/bucketing/testdata/fixture_test_config.json
+++ b/bucketing/testdata/fixture_test_config.json
@@ -570,6 +570,67 @@
           ]
         }
       ]
+    },
+    {
+      "_id": "614ef8aa475928459060721d",
+      "type": "experiment",
+      "key": "header-copy",
+      "configuration": {
+        "_id": "61536f62502d80fff97ed641",
+        "targets": [
+          {
+            "_id": "61536f468fd67f0091982532",
+            "_audience": {
+              "filters": {
+                "filters": [
+                  {
+                    "type": "all",
+                    "subType": "",
+                    "comparator": "",
+                    "values": []
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "distribution": [
+              {
+                "_variation": "615382338424cb11646d9669",
+                "percentage": 0.5
+              },
+              {
+                "_variation": "615382338424cb11646d9670",
+                "percentage": 0.5
+              }
+            ],
+            "bucketingKey": "favouriteFood"
+          }
+        ]
+      },
+      "variations": [
+        {
+          "_id": "615382338424cb11646d9669",
+          "name": "New Copy",
+          "key": "new-copy",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71x",
+              "value": "New!"
+            }
+          ]
+        },
+        {
+          "_id": "615382338424cb11646d9670",
+          "name": "Old Copy",
+          "key": "old-copy",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71x",
+              "value": "default header"
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": [
@@ -622,6 +683,11 @@
       "_id": "61538937b0a70b58ae6af71f",
       "type": "String",
       "key": "feature4Var"
+    },
+    {
+      "_id": "61538937b0a70b58ae6af71x",
+      "type": "String",
+      "key": "experiment1Var"
     }
   ],
   "variableHashes": {

--- a/bucketing/testdata/fixture_test_v2_config.json
+++ b/bucketing/testdata/fixture_test_v2_config.json
@@ -570,6 +570,136 @@
           ]
         }
       ]
+    },
+    {
+      "_id": "614ef8aa475928459060721d",
+      "type": "experiment",
+      "key": "header-copy",
+      "configuration": {
+        "_id": "61536f62502d80fff97ed641",
+        "targets": [
+          {
+            "_id": "61536f468fd67f0091982532",
+            "_audience": {
+              "filters": {
+                "filters": [
+                  {
+                    "type": "all",
+                    "subType": "",
+                    "comparator": "",
+                    "values": []
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "distribution": [
+              {
+                "_variation": "615382338424cb11646d9669",
+                "percentage": 0.5
+              },
+              {
+                "_variation": "615382338424cb11646d9670",
+                "percentage": 0.5
+              }
+            ],
+            "bucketingKey": "favouriteFood"
+          }
+        ]
+      },
+      "variations": [
+        {
+          "_id": "615382338424cb11646d9669",
+          "name": "New Copy",
+          "key": "new-copy",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71x",
+              "value": "New!"
+            }
+          ]
+        },
+        {
+          "_id": "615382338424cb11646d9670",
+          "name": "Old Copy",
+          "key": "old-copy",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71x",
+              "value": "default header"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "_id": "614ef8aa475928459060721e",
+      "type": "permission",
+      "key": "feature_access",
+      "configuration": {
+        "_id": "61536f62502d80fff97ed642",
+        "targets": [
+          {
+            "_id": "61536f468fd67f0091982533",
+            "_audience": {
+              "filters": {
+                "filters": [
+                  {
+                    "type": "all",
+                    "subType": "",
+                    "comparator": "",
+                    "values": []
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "distribution": [
+              {
+                "_variation": "615382338424cb11646d9671",
+                "percentage": 1
+              }
+            ],
+            "rollout": {
+              "type": "gradual",
+              "startPercentage": 0,
+              "startDate": "2024-04-05T17:58:32.318Z",
+              "stages": [
+                {
+                  "type": "linear",
+                  "percentage": 1,
+                  "date": "2034-04-07T17:58:32.319Z"
+                }
+              ]
+            },
+            "bucketingKey": "numericId"
+          }
+        ]
+      },
+      "variations": [
+        {
+          "_id": "615382338424cb11646d9671",
+          "name": "Has Access",
+          "key": "has-access",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71g",
+              "value": true
+            }
+          ]
+        },
+        {
+          "_id": "615382338424cb11646d9672",
+          "name": "No Access",
+          "key": "no-access",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71g",
+              "value": false
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": [
@@ -622,6 +752,16 @@
       "_id": "61538937b0a70b58ae6af71f",
       "type": "String",
       "key": "feature4Var"
+    },
+    {
+      "_id": "61538937b0a70b58ae6af71x",
+      "type": "String",
+      "key": "experiment_var"
+    },
+    {
+      "_id": "61538937b0a70b58ae6af71g",
+      "type": "Boolean",
+      "key": "new_feature"
     }
   ],
   "variableHashes": {

--- a/bucketing/testdata/fixture_test_v2_config.json
+++ b/bucketing/testdata/fixture_test_v2_config.json
@@ -700,6 +700,67 @@
           ]
         }
       ]
+    },
+    {
+      "_id": "614ef8aa475928459060721f",
+      "type": "ops",
+      "key": "operational_guard",
+      "configuration": {
+        "_id": "61536f62502d80fff97ed643",
+        "targets": [
+          {
+            "_id": "61536f468fd67f0091982535",
+            "_audience": {
+              "filters": {
+                "filters": [
+                  {
+                    "type": "all",
+                    "subType": "",
+                    "comparator": "",
+                    "values": []
+                  }
+                ],
+                "operator": "and"
+              }
+            },
+            "distribution": [
+              {
+                "_variation": "615382338424cb11646d9673",
+                "percentage": 0.5
+              },
+              {
+                "_variation": "615382338424cb11646d9674",
+                "percentage": 0.5
+              }
+            ],
+            "bucketingKey": "isSubscriber"
+          }
+        ]
+      },
+      "variations": [
+        {
+          "_id": "615382338424cb11646d9673",
+          "name": "Has Access",
+          "key": "has-access",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71h",
+              "value": true
+            }
+          ]
+        },
+        {
+          "_id": "615382338424cb11646d9674",
+          "name": "No Access",
+          "key": "no-access",
+          "variables": [
+            {
+              "_var": "61538937b0a70b58ae6af71h",
+              "value": false
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": [
@@ -762,6 +823,11 @@
       "_id": "61538937b0a70b58ae6af71g",
       "type": "Boolean",
       "key": "new_feature"
+    },
+    {
+      "_id": "61538937b0a70b58ae6af71h",
+      "type": "Boolean",
+      "key": "gated_access"
     }
   ],
   "variableHashes": {


### PR DESCRIPTION
- feat: add support for alternate key bucketing rollouts and random distributions
  - supports String, Number and Boolean types for alternate keys
- chore: updates test data and test cases to ensure consistent bucketing for users with and without the alternate key defined