### PR TITLE
feat: enable SSE connections by default

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -16,7 +16,7 @@ type EventQueueOptions = api.EventQueueOptions
 
 type AdvancedOptions struct {
 	OverridePlatformData *api.PlatformData
-	OverrideConfigWithV1        bool
+	OverrideConfigWithV1 bool
 }
 
 type Options struct {
@@ -28,14 +28,16 @@ type Options struct {
 	DisableAutomaticEventLogging bool          `json:"disableAutomaticEventLogging,omitempty"`
 	DisableCustomEventLogging    bool          `json:"disableCustomEventLogging,omitempty"`
 	DisableETagMatching          bool          `json:"disableETagMatching,omitempty"`
-	EnableBetaRealtimeUpdates    bool          `json:"enableRealtimeUpdates,omitempty"`
-	MaxEventQueueSize            int           `json:"maxEventsPerFlush,omitempty"`
-	FlushEventQueueSize          int           `json:"minEventsPerFlush,omitempty"`
-	ConfigCDNURI                 string
-	EventsAPIURI                 string
-	ClientEventHandler           chan api.ClientEvent
-	BucketingAPIURI              string
-	Logger                       util.Logger
+	DisableRealtimeUpdates       bool          `json:"disableRealtimeUpdates,omitempty"`
+	// Deprecated: EnableBetaRealtimeUpdates is no longer supported. SSE connections are enabled by default.
+	EnableBetaRealtimeUpdates bool `json:"enableRealtimeUpdates,omitempty"`
+	MaxEventQueueSize         int  `json:"maxEventsPerFlush,omitempty"`
+	FlushEventQueueSize       int  `json:"minEventsPerFlush,omitempty"`
+	ConfigCDNURI              string
+	EventsAPIURI              string
+	ClientEventHandler        chan api.ClientEvent
+	BucketingAPIURI           string
+	Logger                    util.Logger
 	AdvancedOptions
 }
 

--- a/testing_helpers_test.go
+++ b/testing_helpers_test.go
@@ -33,12 +33,12 @@ var (
 		// use defaults that will be set by the CheckDefaults
 		EventFlushIntervalMS:    time.Second * 30,
 		ConfigPollingIntervalMS: time.Second * 10,
+		DisableRealtimeUpdates:  true,
 	}
 	test_options_sse = &Options{
 		// use defaults that will be set by the CheckDefaults
-		EventFlushIntervalMS:      time.Second * 30,
-		ConfigPollingIntervalMS:   time.Second * 10,
-		EnableBetaRealtimeUpdates: true,
+		EventFlushIntervalMS:    time.Second * 30,
+		ConfigPollingIntervalMS: time.Second * 10,
 	}
 	benchmarkEnableConfigUpdates bool
 	benchmarkEnableEvents        bool


### PR DESCRIPTION
- enable SSE connetions by default, add `DisableRealtimeUpdates` option
- depricate `EnableBetaRealtimeUpdates` option


feat: enable SSE connections by default


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
