### PR TITLE
feat: Allow setting upper bound on config polling times when SSE is connected

### DIFF
--- a/configmanager.go
+++ b/configmanager.go
@@ -124,7 +124,14 @@ func (e *EnvironmentConfigManager) ssePollingManager() {
 				e.StartPolling(e.options.ConfigPollingIntervalMS)
 
 			case api.ClientEventType_InternalSSEConnected:
-				e.StartPolling(time.Minute * 10)
+				var pollingInterval time.Duration
+				if e.options.AdvancedOptions.OverrideMaxSSEPolling > 0 {
+					pollingInterval = e.options.AdvancedOptions.OverrideMaxSSEPolling
+				} else {
+					pollingInterval = time.Minute * 5
+				}
+				util.Infof("SSE Connected - increasing polling interval to - %v", pollingInterval)
+				e.StartPolling(pollingInterval)
 
 			case api.ClientEventType_ConfigUpdated:
 				eventData := event.EventData.(map[string]string)

--- a/configuration.go
+++ b/configuration.go
@@ -15,8 +15,9 @@ import (
 type EventQueueOptions = api.EventQueueOptions
 
 type AdvancedOptions struct {
-	OverridePlatformData *api.PlatformData
-	OverrideConfigWithV1 bool
+	OverridePlatformData  *api.PlatformData
+	OverrideConfigWithV1  bool
+	OverrideMaxSSEPolling time.Duration
 }
 
 type Options struct {
@@ -72,6 +73,11 @@ func (o *Options) CheckDefaults() {
 		util.Warnf("ConfigPollingIntervalMS cannot be less than 1 second. Defaulting to 10 seconds.")
 		o.ConfigPollingIntervalMS = time.Second * 10
 	}
+
+	if o.AdvancedOptions.OverrideMaxSSEPolling != 0 && o.AdvancedOptions.OverrideMaxSSEPolling < time.Second*1 {
+		o.AdvancedOptions.OverrideMaxSSEPolling = time.Second * 1
+	}
+
 	if o.RequestTimeout <= time.Second*5 {
 		o.RequestTimeout = time.Second * 5
 	}


### PR DESCRIPTION
In a case where SSE connects successfully and then for another reason disconnects and fails to reconnect - polling is stuck at 10 minutes. 

For cases where you don't want this long of a period - set an upper bound of how long the user wants to set the polling frequency to.
