### PR TITLE
fix: Allow client custom data to be set prior to initialization for a given SDK Key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
       run: >
         go test -run=^$ -bench "^Benchmark.*_VariableSerial$" -benchmem .
         | tee /dev/stderr
-        | grep '0 allocs/op'
+        | grep '1 allocs/op'
         || ( echo "::error title=Heap allocations detected in variable evaluations::The variable evaluation flow cannot have any allocations, or performance will degrade at high concurrency. See https://www.notion.so/How-to-profile-with-Go-613eb85b95c74df898552958f6b1541f for more information on how to resolve this."; false )
 

--- a/client.go
+++ b/client.go
@@ -499,14 +499,13 @@ func (c *Client) FlushEvents() error {
 
 func (c *Client) SetClientCustomData(customData map[string]interface{}) error {
 	if c.IsLocalBucketing() {
-		if c.isInitialized {
+		if c.localBucketing != nil {
 			return c.localBucketing.SetClientCustomData(customData)
 		} else {
 			util.Warnf("SetClientCustomData called before client initialized")
 			return nil
 		}
 	}
-
 	return errors.New("SetClientCustomData is not available in cloud bucketing mode")
 }
 

--- a/configmanager.go
+++ b/configmanager.go
@@ -184,9 +184,6 @@ func (e *EnvironmentConfigManager) StartPolling(interval time.Duration) {
 	e.pollingManager = pollingManager
 	go func() {
 		for {
-			if e.pollingManager == nil {
-				return
-			}
 			select {
 			case <-e.context.Done():
 				util.Warnf("Stopping config polling.")


### PR DESCRIPTION
This only needs to check whether or not the local bucketing engine is set properly. Not whether the client is initialized.
