### PR TITLE
feat: pass evaluation metadata to after and finally hooks

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -3,7 +3,6 @@ name: Run Test Harness
 on:
   - pull_request
 
-
 jobs:
   harness-tests:
     name: Harness Tests
@@ -13,8 +12,5 @@ jobs:
       - uses: DevCycleHQ/test-harness@main
         with:
           sdks-to-test: '["go"]'
-          sdk-github-sha: ${{github.event.pull_request.head.sha}} 
-          sdk-capabilities: '["cloud","edgeDB","clientCustomData","defaultReason","etagReporting","lastModifiedHeader","sdkConfigEvent","clientUUID","v2Config", "evalReason", "cloudEvalReason", "eventsEvalReason", "baseEvalReason", "multithreading"]'
-
-
-
+          sdk-github-sha: ${{github.event.pull_request.head.sha}}
+          sdk-capabilities: '["cloud","edgeDB","clientCustomData","defaultReason","etagReporting","lastModifiedHeader","sdkConfigEvent","clientUUID","v2Config", "evalReason", "cloudEvalReason", "eventsEvalReason", "multithreading"]'

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -13,4 +13,3 @@ jobs:
         with:
           sdks-to-test: '["go"]'
           sdk-github-sha: ${{github.event.pull_request.head.sha}}
-          sdk-capabilities: '["cloud","edgeDB","clientCustomData","defaultReason","etagReporting","lastModifiedHeader","sdkConfigEvent","clientUUID","v2Config", "evalReason", "cloudEvalReason", "eventsEvalReason", "multithreading"]'

--- a/aliases.go
+++ b/aliases.go
@@ -11,6 +11,7 @@ type ErrorResponse = api.ErrorResponse
 type BucketedUserConfig = api.BucketedUserConfig
 type BaseVariable = api.BaseVariable
 type Variable = api.Variable
+type VariableMetadata = api.VariableMetadata
 type ReadOnlyVariable = api.ReadOnlyVariable
 type User = api.User
 type UserDataAndEventsBody = api.UserDataAndEventsBody

--- a/api/model_variable.go
+++ b/api/model_variable.go
@@ -26,6 +26,10 @@ type Variable struct {
 	IsDefaulted  bool        `json:"isDefaulted"`
 }
 
+type VariableMetadata struct {
+	FeatureId string `json:"featureId,omitempty"`
+}
+
 type EvalDetails struct {
 	Reason   EvaluationReason `json:"reason"`
 	Details  string           `json:"details"`

--- a/bucketing/bucketing.go
+++ b/bucketing/bucketing.go
@@ -267,14 +267,14 @@ func GenerateBucketedConfig(sdkKey string, user api.PopulatedUser, clientCustomD
 	}, nil
 }
 
-func VariableForUser(sdkKey string, user api.PopulatedUser, variableKey string, expectedVariableType string, eventQueue *EventQueue, clientCustomData map[string]interface{}) (variableType string, variableValue any, evalReason api.EvaluationReason, evalDetails string, err error) {
+func VariableForUser(sdkKey string, user api.PopulatedUser, variableKey string, expectedVariableType string, eventQueue *EventQueue, clientCustomData map[string]interface{}) (variableType string, variableValue any, featureId string, evalReason api.EvaluationReason, evalDetails string, err error) {
 	variableType, variableValue, featureId, variationId, evalReason, err := generateBucketedVariableForUser(sdkKey, user, variableKey, clientCustomData)
 	if err != nil {
 		eventErr := eventQueue.QueueVariableDefaultedEvent(variableKey, BucketResultErrorToDefaultReason(err))
 		if eventErr != nil {
 			util.Warnf("Failed to queue variable defaulted event: %s", eventErr)
 		}
-		return "", nil, evalReason, string(BucketResultErrorToDefaultReason(err)), err
+		return "", nil, "", evalReason, string(BucketResultErrorToDefaultReason(err)), err
 	}
 
 	if !isVariableTypeValid(variableType, expectedVariableType) && expectedVariableType != "" {
@@ -283,7 +283,7 @@ func VariableForUser(sdkKey string, user api.PopulatedUser, variableKey string, 
 		if eventErr != nil {
 			util.Warnf("Failed to queue variable defaulted event: %s", eventErr)
 		}
-		return "", nil, evalReason, string(BucketResultErrorToDefaultReason(err)), err
+		return "", nil, "", evalReason, string(BucketResultErrorToDefaultReason(err)), err
 	}
 
 	eventErr := eventQueue.QueueVariableEvaluatedEvent(variableKey, featureId, variationId, evalReason)
@@ -291,7 +291,7 @@ func VariableForUser(sdkKey string, user api.PopulatedUser, variableKey string, 
 		util.Warnf("Failed to queue variable evaluated event: %s", eventErr)
 	}
 
-	return
+	return variableType, variableValue, featureId, evalReason, string(BucketResultErrorToDefaultReason(err)), err
 }
 
 func isVariableTypeValid(variableType string, expectedVariableType string) bool {

--- a/bucketing/config_manager.go
+++ b/bucketing/config_manager.go
@@ -75,9 +75,3 @@ func HasConfig(sdkKey string) bool {
 	_, ok := internalConfigs[sdkKey]
 	return ok
 }
-
-func clearConfigs() {
-	configMutex.Lock()
-	defer configMutex.Unlock()
-	internalConfigs = make(map[string]*configBody)
-}

--- a/bucketing/configuration.go
+++ b/bucketing/configuration.go
@@ -10,4 +10,3 @@ type NativeBucketingConfiguration struct {
 	DisableCustomEventLogging    bool          `json:"disableCustomEventLogging"`
 }
 
-var configuration = NativeBucketingConfiguration{}

--- a/client.go
+++ b/client.go
@@ -64,7 +64,7 @@ type LocalBucketing interface {
 	InternalEventQueue
 	GenerateBucketedConfigForUser(user User) (ret *BucketedUserConfig, err error)
 	SetClientCustomData(map[string]interface{}) error
-	Variable(user User, key string, variableType string) (variable Variable, err error)
+	Variable(user User, key string, variableType string) (variable Variable, metadata EvaluationMetadata, err error)
 	Close()
 }
 
@@ -320,7 +320,7 @@ func (c *Client) Variable(userdata User, key string, defaultValue interface{}) (
 			hookError = c.evalHookRunner.RunBeforeHooks(hooks, hookContext)
 		}
 
-		variable, err = c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
+		variable, _, err = c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
 
 		hookContext.VariableDetails = variable
 		if hookError == nil {
@@ -335,16 +335,17 @@ func (c *Client) Variable(userdata User, key string, defaultValue interface{}) (
 			c.evalHookRunner.RunErrorHooks(hooks, hookContext, err)
 		}
 	} else {
-		return c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
+		variable, _, err := c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
+		return variable, err
 	}
 
 	return variable, nil
 }
 
-func (c *Client) evaluateVariable(userdata User, key string, variableType string, defaultValue interface{}, convertedDefaultValue interface{}, variable Variable) (Variable, error) {
+func (c *Client) evaluateVariable(userdata User, key string, variableType string, defaultValue interface{}, convertedDefaultValue interface{}, variable Variable) (Variable, EvaluationMetadata, error) {
 	// Perform variable evaluation
 	if c.IsLocalBucketing() {
-		bucketedVariable, err := c.localBucketing.Variable(userdata, key, variableType)
+		bucketedVariable, metadata, err := c.localBucketing.Variable(userdata, key, variableType)
 
 		sameTypeAsDefault := compareTypes(bucketedVariable.Value, convertedDefaultValue)
 		// if we have a value from the bucketed config and its the same type as the default value or the default value is nil, we can use the value
@@ -369,7 +370,7 @@ func (c *Client) evaluateVariable(userdata User, key string, variableType string
 			}
 		}
 
-		return variable, err
+		return variable, metadata, err
 	}
 
 	populatedUser := userdata.GetPopulatedUser(c.platformData)
@@ -389,10 +390,11 @@ func (c *Client) evaluateVariable(userdata User, key string, variableType string
 
 	// userdata params
 	postBody = &populatedUser
+	metadata := EvaluationMetadata{}
 
 	r, body, err := c.performRequest(path, httpMethod, postBody, headers, queryParams)
 	if err != nil {
-		return variable, err
+		return variable, metadata, err
 	}
 
 	if r.StatusCode < 300 {
@@ -414,7 +416,7 @@ func (c *Client) evaluateVariable(userdata User, key string, variableType string
 				)
 			}
 
-			return variable, err
+			return variable, metadata, err
 		}
 	}
 
@@ -423,10 +425,10 @@ func (c *Client) evaluateVariable(userdata User, key string, variableType string
 	err = decode(&v, body, r.Header.Get("Content-Type"))
 	if err != nil {
 		util.Warnf("Error decoding response body %s", err)
-		return variable, nil
+		return variable, metadata, nil
 	}
 	util.Warnf(v.Message)
-	return variable, nil
+	return variable, metadata, nil
 }
 
 func (c *Client) AllVariables(user User) (map[string]ReadOnlyVariable, error) {

--- a/client.go
+++ b/client.go
@@ -64,7 +64,7 @@ type LocalBucketing interface {
 	InternalEventQueue
 	GenerateBucketedConfigForUser(user User) (ret *BucketedUserConfig, err error)
 	SetClientCustomData(map[string]interface{}) error
-	Variable(user User, key string, variableType string) (variable Variable, metadata EvaluationMetadata, err error)
+	Variable(user User, key string, variableType string) (variable Variable, metadata VariableMetadata, err error)
 	Close()
 }
 
@@ -320,7 +320,7 @@ func (c *Client) Variable(userdata User, key string, defaultValue interface{}) (
 			hookError = c.evalHookRunner.RunBeforeHooks(hooks, hookContext)
 		}
 
-		var metadata EvaluationMetadata
+		var metadata VariableMetadata
 		variable, metadata, err = c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
 
 		hookContext.VariableDetails = variable
@@ -343,7 +343,7 @@ func (c *Client) Variable(userdata User, key string, defaultValue interface{}) (
 	return variable, nil
 }
 
-func (c *Client) evaluateVariable(userdata User, key string, variableType string, defaultValue interface{}, convertedDefaultValue interface{}, variable Variable) (Variable, EvaluationMetadata, error) {
+func (c *Client) evaluateVariable(userdata User, key string, variableType string, defaultValue interface{}, convertedDefaultValue interface{}, variable Variable) (Variable, VariableMetadata, error) {
 	// Perform variable evaluation
 	if c.IsLocalBucketing() {
 		bucketedVariable, metadata, err := c.localBucketing.Variable(userdata, key, variableType)
@@ -391,7 +391,7 @@ func (c *Client) evaluateVariable(userdata User, key string, variableType string
 
 	// userdata params
 	postBody = &populatedUser
-	metadata := EvaluationMetadata{}
+	metadata := VariableMetadata{}
 
 	r, body, err := c.performRequest(path, httpMethod, postBody, headers, queryParams)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -320,7 +320,7 @@ func (c *Client) Variable(userdata User, key string, defaultValue interface{}) (
 			hookError = c.evalHookRunner.RunBeforeHooks(hooks, hookContext)
 		}
 
-		metadata := EvaluationMetadata{}
+		var metadata EvaluationMetadata
 		variable, metadata, err = c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
 
 		hookContext.VariableDetails = variable

--- a/client.go
+++ b/client.go
@@ -320,15 +320,16 @@ func (c *Client) Variable(userdata User, key string, defaultValue interface{}) (
 			hookError = c.evalHookRunner.RunBeforeHooks(hooks, hookContext)
 		}
 
-		variable, _, err = c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
+		metadata := EvaluationMetadata{}
+		variable, metadata, err = c.evaluateVariable(userdata, key, variableType, defaultValue, convertedDefaultValue, variable)
 
 		hookContext.VariableDetails = variable
 		if hookError == nil {
-			hookError = c.evalHookRunner.RunAfterHooks(hooks, hookContext, variable)
+			hookError = c.evalHookRunner.RunAfterHooks(hooks, hookContext, variable, metadata)
 		}
 
 		// Always run onFinally hooks
-		c.evalHookRunner.RunOnFinallyHooks(hooks, hookContext, variable)
+		c.evalHookRunner.RunOnFinallyHooks(hooks, hookContext, variable, metadata)
 		if hookError != nil {
 			c.evalHookRunner.RunErrorHooks(hooks, hookContext, hookError)
 		} else if err != nil {

--- a/client_hooks_test.go
+++ b/client_hooks_test.go
@@ -22,13 +22,13 @@ func TestClientWithHooks(t *testing.T) {
 			return beforeHookError
 		}
 
-		afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			afterCalled = true
 			t.Error("After hook should not be called when before hook fails")
 			return nil
 		}
 
-		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			onFinallyCalled = true
 			assert.Equal(t, "test-key", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -96,11 +96,11 @@ func TestClientWithHooks(t *testing.T) {
 			return nil
 		}
 
-		afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			return afterHookError
 		}
 
-		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			// This should be called even when after hook fails
 			assert.Equal(t, "test-key", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -169,7 +169,7 @@ func TestClientWithHooks(t *testing.T) {
 			return nil
 		}
 
-		afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			afterCalled = true
 			assert.Equal(t, "test", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -183,12 +183,12 @@ func TestClientWithHooks(t *testing.T) {
 			assert.Equal(t, true, variable.Value)
 			assert.False(t, variable.IsDefaulted)
 
-			assert.Equal(t, "6216422850294da359385e8b", metadata.FeatureId)
+			assert.NotEmpty(t, metadata.FeatureId)
 
 			return nil
 		}
 
-		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			onFinallyCalled = true
 			assert.Equal(t, "test", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -197,7 +197,7 @@ func TestClientWithHooks(t *testing.T) {
 			assert.Equal(t, true, variable.Value)
 			assert.False(t, variable.IsDefaulted)
 
-			assert.Equal(t, "6216422850294da359385e8b", metadata.FeatureId)
+			assert.NotEmpty(t, metadata.FeatureId)
 
 			return nil
 		}
@@ -270,11 +270,11 @@ func TestClientWithHooks(t *testing.T) {
 				executionOrder = append(executionOrder, 1)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 4)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 6)
 				return nil
 			},
@@ -286,11 +286,11 @@ func TestClientWithHooks(t *testing.T) {
 				executionOrder = append(executionOrder, 2)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 3)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 5)
 				return nil
 			},
@@ -335,14 +335,14 @@ func TestClientWithHooksCloud(t *testing.T) {
 			return beforeHookError
 		}
 
-		afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			afterCalled = true
 			t.Error("After hook should not be called when before hook fails")
 			assert.Equal(t, "", metadata.FeatureId)
 			return nil
 		}
 
-		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			onFinallyCalled = true
 			assert.Equal(t, "test-key", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -418,11 +418,11 @@ func TestClientWithHooksCloud(t *testing.T) {
 			return nil
 		}
 
-		afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			return afterHookError
 		}
 
-		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			// This should be called even when after hook fails
 			assert.Equal(t, "test-key", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -499,7 +499,7 @@ func TestClientWithHooksCloud(t *testing.T) {
 			return nil
 		}
 
-		afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			afterCalled = true
 			assert.Equal(t, "test-key", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -516,7 +516,7 @@ func TestClientWithHooksCloud(t *testing.T) {
 			return nil
 		}
 
-		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+		onFinallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 			onFinallyCalled = true
 			assert.Equal(t, "test-key", context.Key)
 			assert.Equal(t, "test-user", context.User.UserId)
@@ -612,11 +612,11 @@ func TestClientWithHooksCloud(t *testing.T) {
 				executionOrder = append(executionOrder, 1)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 4)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 6)
 				return nil
 			},
@@ -628,11 +628,11 @@ func TestClientWithHooksCloud(t *testing.T) {
 				executionOrder = append(executionOrder, 2)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 3)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 5)
 				return nil
 			},

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -2,7 +2,6 @@ package devcycle
 
 import (
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/devcyclehq/go-server-sdk/v2/util"
@@ -31,7 +30,6 @@ func (c *Client) setLBClient(sdkKey string, options *Options) error {
 type NativeLocalBucketing struct {
 	sdkKey       string
 	options      *Options
-	configMutex  sync.RWMutex
 	platformData *api.PlatformData
 	eventQueue   *bucketing.EventQueue
 	clientUUID   string

--- a/client_native_bucketing.go
+++ b/client_native_bucketing.go
@@ -94,7 +94,7 @@ func (n *NativeLocalBucketing) SetClientCustomData(customData map[string]interfa
 	return nil
 }
 
-func (n *NativeLocalBucketing) Variable(user User, variableKey string, variableType string) (Variable, EvaluationMetadata, error) {
+func (n *NativeLocalBucketing) Variable(user User, variableKey string, variableType string) (Variable, VariableMetadata, error) {
 
 	defaultVar := Variable{
 		BaseVariable: api.BaseVariable{
@@ -112,7 +112,7 @@ func (n *NativeLocalBucketing) Variable(user User, variableKey string, variableT
 	clientCustomData := bucketing.GetClientCustomData(n.sdkKey)
 	populatedUser := user.GetPopulatedUserWithTime(n.platformData, DEFAULT_USER_TIME)
 	resultVariableType, resultValue, featureId, evalReason, evalDetails, err := bucketing.VariableForUser(n.sdkKey, populatedUser, variableKey, variableType, n.eventQueue, clientCustomData)
-	metadata := EvaluationMetadata{}
+	metadata := VariableMetadata{}
 
 	if err != nil {
 		defaultVar.Eval.Details = evalDetails

--- a/config_metadata_test.go
+++ b/config_metadata_test.go
@@ -144,12 +144,12 @@ func TestConfigMetadata_AvailableInAllHooks(t *testing.T) {
 		return nil
 	}
 
-	afterHook := func(context *HookContext, variable *api.Variable) error {
+	afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 		afterMetadata = context.Metadata
 		return nil
 	}
 
-	finallyHook := func(context *HookContext, variable *api.Variable) error {
+	finallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 		finallyMetadata = context.Metadata
 		return nil
 	}
@@ -235,11 +235,11 @@ func TestConfigMetadata_AvailableInErrorHook(t *testing.T) {
 		return &BeforeHookError{HookIndex: 0, Err: fmt.Errorf("simulated before hook error")}
 	}
 
-	afterHook := func(context *HookContext, variable *api.Variable) error {
+	afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 		return nil
 	}
 
-	finallyHook := func(context *HookContext, variable *api.Variable) error {
+	finallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 		return nil
 	}
 

--- a/config_metadata_test.go
+++ b/config_metadata_test.go
@@ -144,12 +144,12 @@ func TestConfigMetadata_AvailableInAllHooks(t *testing.T) {
 		return nil
 	}
 
-	afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+	afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 		afterMetadata = context.Metadata
 		return nil
 	}
 
-	finallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+	finallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 		finallyMetadata = context.Metadata
 		return nil
 	}
@@ -235,11 +235,11 @@ func TestConfigMetadata_AvailableInErrorHook(t *testing.T) {
 		return &BeforeHookError{HookIndex: 0, Err: fmt.Errorf("simulated before hook error")}
 	}
 
-	afterHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+	afterHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 		return nil
 	}
 
-	finallyHook := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+	finallyHook := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 		return nil
 	}
 

--- a/eval_hook.go
+++ b/eval_hook.go
@@ -7,15 +7,15 @@ type EvalHook struct {
 	// Before is called before variable evaluation
 	Before func(context *HookContext) error
 	// After is called after variable evaluation (only if Before didn't error)
-	After func(context *HookContext, variable *api.Variable) error
+	After func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error
 	// OnFinally is called after variable evaluation regardless of errors
-	OnFinally func(context *HookContext, variable *api.Variable) error
+	OnFinally func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error
 	// Error is called when an error occurs during evaluation
 	Error func(context *HookContext, evalError error) error
 }
 
 // NewEvalHook creates a new EvalHook with the provided functions
-func NewEvalHook(before func(context *HookContext) error, after func(context *HookContext, variable *api.Variable) error, onFinally func(context *HookContext, variable *api.Variable) error, error func(context *HookContext, evalError error) error) *EvalHook {
+func NewEvalHook(before func(context *HookContext) error, after func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error, onFinally func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error, error func(context *HookContext, evalError error) error) *EvalHook {
 	return &EvalHook{
 		Before:    before,
 		After:     after,

--- a/eval_hook.go
+++ b/eval_hook.go
@@ -7,15 +7,15 @@ type EvalHook struct {
 	// Before is called before variable evaluation
 	Before func(context *HookContext) error
 	// After is called after variable evaluation (only if Before didn't error)
-	After func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error
+	After func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error
 	// OnFinally is called after variable evaluation regardless of errors
-	OnFinally func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error
+	OnFinally func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error
 	// Error is called when an error occurs during evaluation
 	Error func(context *HookContext, evalError error) error
 }
 
 // NewEvalHook creates a new EvalHook with the provided functions
-func NewEvalHook(before func(context *HookContext) error, after func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error, onFinally func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error, error func(context *HookContext, evalError error) error) *EvalHook {
+func NewEvalHook(before func(context *HookContext) error, after func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error, onFinally func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error, error func(context *HookContext, evalError error) error) *EvalHook {
 	return &EvalHook{
 		Before:    before,
 		After:     after,

--- a/eval_hook_runner.go
+++ b/eval_hook_runner.go
@@ -71,7 +71,7 @@ func (r *EvalHookRunner) RunAfterHooks(hooks []*EvalHook, context *HookContext, 
 	for i := len(hooks) - 1; i >= 0; i-- {
 		hook := hooks[i]
 		if hook.After != nil {
-			if err := hook.After(context, &variable); err != nil {
+			if err := hook.After(context, &variable, &metadata); err != nil {
 				util.Errorf("After hook %d failed: %v", i, err)
 				return &AfterHookError{HookIndex: i, Err: err}
 			}
@@ -88,7 +88,7 @@ func (r *EvalHookRunner) RunOnFinallyHooks(hooks []*EvalHook, context *HookConte
 	for i := len(hooks) - 1; i >= 0; i-- {
 		hook := hooks[i]
 		if hook.OnFinally != nil {
-			if err := hook.OnFinally(context, &variable); err != nil {
+			if err := hook.OnFinally(context, &variable, &metadata); err != nil {
 				util.Errorf("OnFinally hook %d failed: %v", i, err)
 			}
 		}

--- a/eval_hook_runner.go
+++ b/eval_hook_runner.go
@@ -64,7 +64,7 @@ func (r *EvalHookRunner) RunBeforeHooks(hooks []*EvalHook, context *HookContext)
 }
 
 // RunAfterHooks runs all after hooks in reverse order
-func (r *EvalHookRunner) RunAfterHooks(hooks []*EvalHook, context *HookContext, variable api.Variable, metadata EvaluationMetadata) error {
+func (r *EvalHookRunner) RunAfterHooks(hooks []*EvalHook, context *HookContext, variable api.Variable, metadata VariableMetadata) error {
 	if context == nil {
 		return nil
 	}
@@ -81,7 +81,7 @@ func (r *EvalHookRunner) RunAfterHooks(hooks []*EvalHook, context *HookContext, 
 }
 
 // RunOnFinallyHooks runs all onFinally hooks in reverse order
-func (r *EvalHookRunner) RunOnFinallyHooks(hooks []*EvalHook, context *HookContext, variable api.Variable, metadata EvaluationMetadata) {
+func (r *EvalHookRunner) RunOnFinallyHooks(hooks []*EvalHook, context *HookContext, variable api.Variable, metadata VariableMetadata) {
 	if context == nil {
 		return
 	}

--- a/eval_hook_runner.go
+++ b/eval_hook_runner.go
@@ -64,7 +64,7 @@ func (r *EvalHookRunner) RunBeforeHooks(hooks []*EvalHook, context *HookContext)
 }
 
 // RunAfterHooks runs all after hooks in reverse order
-func (r *EvalHookRunner) RunAfterHooks(hooks []*EvalHook, context *HookContext, variable api.Variable) error {
+func (r *EvalHookRunner) RunAfterHooks(hooks []*EvalHook, context *HookContext, variable api.Variable, metadata EvaluationMetadata) error {
 	if context == nil {
 		return nil
 	}
@@ -81,7 +81,7 @@ func (r *EvalHookRunner) RunAfterHooks(hooks []*EvalHook, context *HookContext, 
 }
 
 // RunOnFinallyHooks runs all onFinally hooks in reverse order
-func (r *EvalHookRunner) RunOnFinallyHooks(hooks []*EvalHook, context *HookContext, variable api.Variable) {
+func (r *EvalHookRunner) RunOnFinallyHooks(hooks []*EvalHook, context *HookContext, variable api.Variable, metadata EvaluationMetadata) {
 	if context == nil {
 		return
 	}

--- a/eval_hook_test.go
+++ b/eval_hook_test.go
@@ -49,19 +49,19 @@ func TestEvalHookRunner(t *testing.T) {
 	t.Run("RunAfterHooks - success", func(t *testing.T) {
 		hook1 := NewEvalHook(
 			nil,
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error { return nil },
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error { return nil },
 			nil, nil,
 		)
 		hook2 := NewEvalHook(
 			nil,
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error { return nil },
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error { return nil },
 			nil, nil,
 		)
 
 		runner := NewEvalHookRunner([]*EvalHook{hook1, hook2})
 		context := &HookContext{Key: "test-key"}
 
-		err := runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, EvaluationMetadata{})
+		err := runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, VariableMetadata{})
 		assert.NoError(t, err)
 	})
 
@@ -69,7 +69,7 @@ func TestEvalHookRunner(t *testing.T) {
 		expectedError := errors.New("after hook error")
 		hook := NewEvalHook(
 			nil,
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error { return expectedError },
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error { return expectedError },
 			nil, nil,
 		)
 
@@ -86,7 +86,7 @@ func TestEvalHookRunner(t *testing.T) {
 		runner := NewEvalHookRunner([]*EvalHook{hook})
 		context := &HookContext{Key: "test-key"}
 
-		err := runner.RunAfterHooks([]*EvalHook{hook}, context, variable, EvaluationMetadata{})
+		err := runner.RunAfterHooks([]*EvalHook{hook}, context, variable, VariableMetadata{})
 		require.Error(t, err)
 
 		afterHookError, ok := err.(*AfterHookError)
@@ -99,7 +99,7 @@ func TestEvalHookRunner(t *testing.T) {
 		called := false
 		hook := NewEvalHook(
 			nil, nil,
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				called = true
 				return nil
 			}, nil,
@@ -108,7 +108,7 @@ func TestEvalHookRunner(t *testing.T) {
 		runner := NewEvalHookRunner([]*EvalHook{hook})
 		context := &HookContext{Key: "test-key"}
 
-		runner.RunOnFinallyHooks([]*EvalHook{hook}, context, api.Variable{}, EvaluationMetadata{})
+		runner.RunOnFinallyHooks([]*EvalHook{hook}, context, api.Variable{}, VariableMetadata{})
 		assert.True(t, called)
 	})
 
@@ -137,11 +137,11 @@ func TestEvalHookRunner(t *testing.T) {
 				executionOrder = append(executionOrder, 1)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 4)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 6)
 				return nil
 			},
@@ -153,11 +153,11 @@ func TestEvalHookRunner(t *testing.T) {
 				executionOrder = append(executionOrder, 2)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 3)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+			func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 				executionOrder = append(executionOrder, 5)
 				return nil
 			},
@@ -172,11 +172,11 @@ func TestEvalHookRunner(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run after hooks (should be in reverse order: 3, 4)
-		err = runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, EvaluationMetadata{})
+		err = runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, VariableMetadata{})
 		assert.NoError(t, err)
 
 		// Run onFinally hooks (should be in reverse order: 5, 6)
-		runner.RunOnFinallyHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, EvaluationMetadata{})
+		runner.RunOnFinallyHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, VariableMetadata{})
 
 		// Verify execution order: before hooks in order, after/onFinally hooks in reverse order
 		expectedOrder := []int{1, 2, 3, 4, 5, 6}
@@ -218,11 +218,11 @@ func TestNewEvalHook(t *testing.T) {
 		beforeCalled = true
 		return nil
 	}
-	after := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+	after := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 		afterCalled = true
 		return nil
 	}
-	onFinally := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
+	onFinally := func(context *HookContext, variable *api.Variable, metadata *VariableMetadata) error {
 		onFinallyCalled = true
 		return nil
 	}
@@ -247,11 +247,11 @@ func TestNewEvalHook(t *testing.T) {
 	assert.True(t, beforeCalled)
 
 	// Test that the after hook works
-	err = hook.After(context, &api.Variable{}, &EvaluationMetadata{})
+	err = hook.After(context, &api.Variable{}, &VariableMetadata{})
 	assert.NoError(t, err)
 	assert.True(t, afterCalled)
 
-	err = hook.OnFinally(context, &api.Variable{}, &EvaluationMetadata{})
+	err = hook.OnFinally(context, &api.Variable{}, &VariableMetadata{})
 	assert.NoError(t, err)
 	assert.True(t, onFinallyCalled)
 

--- a/eval_hook_test.go
+++ b/eval_hook_test.go
@@ -49,12 +49,12 @@ func TestEvalHookRunner(t *testing.T) {
 	t.Run("RunAfterHooks - success", func(t *testing.T) {
 		hook1 := NewEvalHook(
 			nil,
-			func(context *HookContext, variable *api.Variable) error { return nil },
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error { return nil },
 			nil, nil,
 		)
 		hook2 := NewEvalHook(
 			nil,
-			func(context *HookContext, variable *api.Variable) error { return nil },
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error { return nil },
 			nil, nil,
 		)
 
@@ -69,7 +69,7 @@ func TestEvalHookRunner(t *testing.T) {
 		expectedError := errors.New("after hook error")
 		hook := NewEvalHook(
 			nil,
-			func(context *HookContext, variable *api.Variable) error { return expectedError },
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error { return expectedError },
 			nil, nil,
 		)
 
@@ -99,7 +99,7 @@ func TestEvalHookRunner(t *testing.T) {
 		called := false
 		hook := NewEvalHook(
 			nil, nil,
-			func(context *HookContext, variable *api.Variable) error {
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 				called = true
 				return nil
 			}, nil,
@@ -137,11 +137,11 @@ func TestEvalHookRunner(t *testing.T) {
 				executionOrder = append(executionOrder, 1)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable) error {
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 				executionOrder = append(executionOrder, 4)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable) error {
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 				executionOrder = append(executionOrder, 6)
 				return nil
 			},
@@ -153,11 +153,11 @@ func TestEvalHookRunner(t *testing.T) {
 				executionOrder = append(executionOrder, 2)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable) error {
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 				executionOrder = append(executionOrder, 3)
 				return nil
 			},
-			func(context *HookContext, variable *api.Variable) error {
+			func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 				executionOrder = append(executionOrder, 5)
 				return nil
 			},
@@ -218,11 +218,11 @@ func TestNewEvalHook(t *testing.T) {
 		beforeCalled = true
 		return nil
 	}
-	after := func(context *HookContext, variable *api.Variable) error {
+	after := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 		afterCalled = true
 		return nil
 	}
-	onFinally := func(context *HookContext, variable *api.Variable) error {
+	onFinally := func(context *HookContext, variable *api.Variable, metadata *EvaluationMetadata) error {
 		onFinallyCalled = true
 		return nil
 	}
@@ -247,11 +247,11 @@ func TestNewEvalHook(t *testing.T) {
 	assert.True(t, beforeCalled)
 
 	// Test that the after hook works
-	err = hook.After(context, &api.Variable{})
+	err = hook.After(context, &api.Variable{}, &EvaluationMetadata{})
 	assert.NoError(t, err)
 	assert.True(t, afterCalled)
 
-	err = hook.OnFinally(context, &api.Variable{})
+	err = hook.OnFinally(context, &api.Variable{}, &EvaluationMetadata{})
 	assert.NoError(t, err)
 	assert.True(t, onFinallyCalled)
 

--- a/eval_hook_test.go
+++ b/eval_hook_test.go
@@ -61,7 +61,7 @@ func TestEvalHookRunner(t *testing.T) {
 		runner := NewEvalHookRunner([]*EvalHook{hook1, hook2})
 		context := &HookContext{Key: "test-key"}
 
-		err := runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{})
+		err := runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, EvaluationMetadata{})
 		assert.NoError(t, err)
 	})
 
@@ -86,7 +86,7 @@ func TestEvalHookRunner(t *testing.T) {
 		runner := NewEvalHookRunner([]*EvalHook{hook})
 		context := &HookContext{Key: "test-key"}
 
-		err := runner.RunAfterHooks([]*EvalHook{hook}, context, variable)
+		err := runner.RunAfterHooks([]*EvalHook{hook}, context, variable, EvaluationMetadata{})
 		require.Error(t, err)
 
 		afterHookError, ok := err.(*AfterHookError)
@@ -108,7 +108,7 @@ func TestEvalHookRunner(t *testing.T) {
 		runner := NewEvalHookRunner([]*EvalHook{hook})
 		context := &HookContext{Key: "test-key"}
 
-		runner.RunOnFinallyHooks([]*EvalHook{hook}, context, api.Variable{})
+		runner.RunOnFinallyHooks([]*EvalHook{hook}, context, api.Variable{}, EvaluationMetadata{})
 		assert.True(t, called)
 	})
 
@@ -172,11 +172,11 @@ func TestEvalHookRunner(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Run after hooks (should be in reverse order: 3, 4)
-		err = runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{})
+		err = runner.RunAfterHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, EvaluationMetadata{})
 		assert.NoError(t, err)
 
 		// Run onFinally hooks (should be in reverse order: 5, 6)
-		runner.RunOnFinallyHooks([]*EvalHook{hook1, hook2}, context, api.Variable{})
+		runner.RunOnFinallyHooks([]*EvalHook{hook1, hook2}, context, api.Variable{}, EvaluationMetadata{})
 
 		// Verify execution order: before hooks in order, after/onFinally hooks in reverse order
 		expectedOrder := []int{1, 2, 3, 4, 5, 6}

--- a/evaluation_metadata.go
+++ b/evaluation_metadata.go
@@ -1,5 +1,0 @@
-package devcycle
-
-type EvaluationMetadata struct {
-	FeatureId string
-}

--- a/evaluation_metadata.go
+++ b/evaluation_metadata.go
@@ -1,0 +1,5 @@
+package devcycle
+
+type EvaluationMetadata struct {
+	FeatureId string
+}

--- a/example/hooks/main.go
+++ b/example/hooks/main.go
@@ -36,7 +36,7 @@ func main() {
 		return nil
 	}
 
-	afterHook := func(context *devcycle.HookContext, variable *api.Variable, metadata *devcycle.EvaluationMetadata) error {
+	afterHook := func(context *devcycle.HookContext, variable *api.Variable, metadata *devcycle.VariableMetadata) error {
 		fmt.Printf("After hook: Variable '%s' evaluated to %v (defaulted: %t)\n",
 			context.Key, context.VariableDetails.Value, context.VariableDetails.IsDefaulted)
 
@@ -51,7 +51,7 @@ func main() {
 		return nil
 	}
 
-	onFinallyHook := func(context *devcycle.HookContext, variable *api.Variable, metadata *devcycle.EvaluationMetadata) error {
+	onFinallyHook := func(context *devcycle.HookContext, variable *api.Variable, metadata *devcycle.VariableMetadata) error {
 		fmt.Printf("OnFinally hook: Completed evaluation of variable '%s'\n", context.Key)
 
 		if context.Metadata != (ConfigMetadata{}) {

--- a/example/hooks/main.go
+++ b/example/hooks/main.go
@@ -36,7 +36,7 @@ func main() {
 		return nil
 	}
 
-	afterHook := func(context *devcycle.HookContext, variable *api.Variable) error {
+	afterHook := func(context *devcycle.HookContext, variable *api.Variable, metadata *devcycle.EvaluationMetadata) error {
 		fmt.Printf("After hook: Variable '%s' evaluated to %v (defaulted: %t)\n",
 			context.Key, context.VariableDetails.Value, context.VariableDetails.IsDefaulted)
 
@@ -51,7 +51,7 @@ func main() {
 		return nil
 	}
 
-	onFinallyHook := func(context *devcycle.HookContext, variable *api.Variable) error {
+	onFinallyHook := func(context *devcycle.HookContext, variable *api.Variable, metadata *devcycle.EvaluationMetadata) error {
 		fmt.Printf("OnFinally hook: Completed evaluation of variable '%s'\n", context.Key)
 
 		if context.Metadata != (ConfigMetadata{}) {

--- a/example/hooks/main.go
+++ b/example/hooks/main.go
@@ -57,7 +57,7 @@ func main() {
 		if context.Metadata != (ConfigMetadata{}) {
 			fmt.Printf("  Evaluated in project: %s\n", context.Metadata.Project.Key)
 			fmt.Printf("  Evaluated in environment: %s\n", context.Metadata.Environment.Key)
-		} else {
+		} else { 
 			fmt.Printf("  Config metadata not available (config not loaded)\n")
 		}
 

--- a/openfeature_provider_test.go
+++ b/openfeature_provider_test.go
@@ -289,19 +289,6 @@ func getProviderForConfig(t *testing.T, cloudBucketing bool) DevCycleProvider {
 	return client.OpenFeatureProvider()
 }
 
-func getProviderForCustomConfig(t *testing.T, config string, cloudBucketing bool) DevCycleProvider {
-	t.Helper()
-	sdkKey := generateTestSDKKey()
-	httpCustomConfigMock(sdkKey, 200, config, false)
-
-	client, err := NewClient(sdkKey, &Options{
-		EnableCloudBucketing: cloudBucketing,
-	})
-	require.NoError(t, err)
-
-	return client.OpenFeatureProvider()
-}
-
 func TestOFBooleanEvaluation_Default(t *testing.T) {
 
 	provider := getProviderForConfig(t, false)


### PR DESCRIPTION
# Changes

- create evaluation metadata with `_feature` as `FeatureId`
- pass in metadata with after and onFinally

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
