### PR TITLE
fix: checkout before setup-go, pin go-version-file to avoid golangci-lint version mismatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,11 +16,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: go.mod
           cache: false
-      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:


### PR DESCRIPTION
## Summary

- `actions/checkout` was running after `actions/setup-go`, so `go.mod` didn't exist when `setup-go` tried to read it with `go-version-file`
- Swapped step order so checkout runs first
- Changed `go-version: stable` to `go-version-file: go.mod` so lint always runs against the Go version declared in the module, avoiding mismatches when the stable Go release moves ahead of the version golangci-lint was built with (currently causes a `file requires newer Go version go1.26 (application built with go1.24)` typecheck error)